### PR TITLE
[FEAT] Update downloading to check for local file

### DIFF
--- a/amocarray/read_move.py
+++ b/amocarray/read_move.py
@@ -29,7 +29,8 @@ MOVE_FILE_METADATA = {
 
 
 @apply_defaults(MOVE_DEFAULT_SOURCE, MOVE_DEFAULT_FILES)
-def read_move(source: str, file_list: str | list[str], transport_only: bool = True) -> list[xr.Dataset]:    
+def read_move(source: str, file_list: str | list[str], transport_only: bool = True,
+              data_dir=None, redownload=False) -> list[xr.Dataset]:    
     """
     Load the MOVE transport dataset from a URL or local file path into xarray Datasets.
 
@@ -54,6 +55,7 @@ def read_move(source: str, file_list: str | list[str], transport_only: bool = Tr
     FileNotFoundError
         If the file cannot be downloaded or does not exist locally.
     """
+    source = utilities.get_local_file(source, data_dir, redownload)
     if transport_only:
         file_list = MOVE_TRANSPORT_FILES
     if isinstance(file_list, str):

--- a/amocarray/read_osnap.py
+++ b/amocarray/read_osnap.py
@@ -42,7 +42,8 @@ OSNAP_FILE_METADATA = {
 }
 
 
-def read_osnap(source: str, file_list: str | list[str], transport_only: bool = True) -> list[xr.Dataset]:  
+def read_osnap(source: str, file_list: str | list[str], transport_only: bool = True,
+               data_dir=None, redownload=False) -> list[xr.Dataset]:  
     """
     Load the OSNAP transport datasets from a URL or local file path into xarray Datasets.
 
@@ -66,6 +67,7 @@ def read_osnap(source: str, file_list: str | list[str], transport_only: bool = T
     FileNotFoundError
         If the file cannot be downloaded or does not exist locally.
     """
+    source = utilities.get_local_file(source, data_dir, redownload)
     # Ensure file_list has a default
     if file_list is None:
         file_list = OSNAP_DEFAULT_FILES

--- a/amocarray/read_rapid.py
+++ b/amocarray/read_rapid.py
@@ -1,7 +1,9 @@
 import os
 import xarray as xr
 
+# Import the modules used
 from amocarray import utilities
+# Import the apply_defaults decorator function directly
 from amocarray.utilities import apply_defaults
 
 # Inline metadata dictionary
@@ -25,7 +27,7 @@ RAPID_DEFAULT_FILES = [
 #https://rapid.ac.uk/sites/default/files/rapid_data/moc_vertical.nc
 #https://rapid.ac.uk/sites/default/files/rapid_data/moc_transports.nc
 @apply_defaults(RAPID_DEFAULT_SOURCE, RAPID_DEFAULT_FILES)
-def read_rapid(source: str, file_list: str | list[str], transport_only: bool = True) -> list[xr.Dataset]:    
+def read_rapid(source: str, file_list: str | list[str], transport_only: bool = True, data_dir=None, redownload=False) -> list[xr.Dataset]:    
     """
     Load the RAPID transport dataset from a URL or local file path into an xarray.Dataset.
 
@@ -50,6 +52,7 @@ def read_rapid(source: str, file_list: str | list[str], transport_only: bool = T
     FileNotFoundError
         If no valid NetCDF files are found in the provided file list.
     """
+    source = utilities.get_local_file(source, data_dir, redownload)
     if file_list is None:
         file_list = RAPID_DEFAULT_FILES
     if transport_only:

--- a/amocarray/read_samba.py
+++ b/amocarray/read_samba.py
@@ -44,8 +44,8 @@ SAMBA_FILE_METADATA = {
 
 
 
-def read_samba(source: str = None,
-               file_list: str | list[str] = None, transport_only: bool = True) -> list[xr.Dataset]:
+def read_samba(source: str = None, file_list: str | list[str] = None, transport_only: bool = True,
+               data_dir=None, redownload=False) -> list[xr.Dataset]:
     """
     Load the SAMBA transport datasets from remote URL or local file path into xarray Datasets.
 
@@ -69,6 +69,7 @@ def read_samba(source: str = None,
     FileNotFoundError
         If the file cannot be downloaded or does not exist locally.
     """
+    source = utilities.get_local_file(source, data_dir, redownload)
     # Ensure file_list has a default
     if file_list is None:
         file_list = SAMBA_DEFAULT_FILES

--- a/amocarray/readers.py
+++ b/amocarray/readers.py
@@ -44,7 +44,7 @@ def load_sample_dataset(dataset_name="moc_transports.nc", data_dir="../data"):
     return xr.open_dataset(file_path)
 
 def load_dataset(array_name: str, source: str = None, file_list: str | list[str] = None,
-             transport_only: bool = True):
+             transport_only: bool = True, data_dir=None, redownload=False) -> list[xr.Dataset]:
     """
     Load raw datasets from a selected AMOC observing array.
 
@@ -74,7 +74,7 @@ def load_dataset(array_name: str, source: str = None, file_list: str | list[str]
         If an unknown array name is provided.
     """
     reader = _get_reader(array_name)
-    return reader(source=source, file_list=file_list, transport_only=transport_only)
+    return reader(source=source, file_list=file_list, transport_only=transport_only, data_dir=data_dir, redownload=redownload)
 
 
 def _get_reader(array_name: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""
+Pytest fixture for monkey patching the download_file function.
+
+This replaces the real download logic with a fake function during tests,
+so that no actual network requests are made. Instead, the fake function 
+creates a dummy local file. Keeps tests fast, isolated, and reliable.
+"""
+import pytest
+from pathlib import Path
+
+@pytest.fixture
+def mock_download_file(monkeypatch):
+    """
+    Fixture to mock the download_file function in utilities.py.
+    Instead of downloading, it writes dummy data to the destination.
+    """
+
+    def fake_download_file(source_url, destination):
+        destination = Path(destination)
+        destination.write_text("fake data")
+
+    monkeypatch.setattr("amocarray.utilities.download_file", fake_download_file)


### PR DESCRIPTION
- Added additional optional inputs to `read_move.py`, `read_rapid.py` etc to check for redownload
- Added function  `utilities.get_local_file(source, data_dir, redownload)` to check whether to redownload or load from local
- Added a `conftest.py` for "monkeypatching", to replace the actual downloads with a mock download, to make testing independent of whether the external URLs are working.