### PR TITLE
[CLEANUPremove log statements in console, extend plot

### DIFF
--- a/amocarray/logger.py
+++ b/amocarray/logger.py
@@ -90,6 +90,6 @@ def setup_logger(array_name: str, output_dir: str = "logs") -> None:
         log.handlers.clear()
 
         log.addHandler(file_handler)
-        log.addHandler(console_handler)
+ #       log.addHandler(console_handler)
 
         log.info(f"Logger initialized for array: {array_name}, writing to {log_path}")

--- a/amocarray/plotters.py
+++ b/amocarray/plotters.py
@@ -347,7 +347,7 @@ def plot_monthly_anomalies(
     for ax in axes:
         ax.spines["top"].set_visible(False)
         ax.spines["right"].set_visible(False)
-        ax.set_xlim([pd.Timestamp("2000-01-01"), pd.Timestamp("2022-12-31")])
+        ax.set_xlim([pd.Timestamp("2000-01-01"), pd.Timestamp("2023-12-31")])
         ax.set_clip_on(False)
         ax.set_yticks(range(int(ax.get_ylim()[0]) + 1, int(ax.get_ylim()[1]) + 1, 5))
     axes[0].set_ylim([5, 25])  # OSNAP


### PR DESCRIPTION
## [CLEANUP/MINOR] Extend plot for RAPID, clean up log statements in demo.ipynb.

**Description:**

- Extended `plotters.plot_monthly_anomalies()` to 2023-12-31 to show all of RAPID since the April update.
- Removed repeat of logging statements to the console for a cleaner `demo.ipynb`

**Checklist:**

- [x] I have followed the [coding conventions](https://amoccommunity.github.io/amocarray/conventions.html).
- [ ] I have updated or added tests to cover my changes.
- [ ] I have updated the documentation if needed.
- [x] I have run `pytest` to check that all tests pass.
- [ ] I have run `pre-commit run --all-files` to lint and format the code.

**Related Issues / Pull Requests:**

- Related to #45 

