### PR TITLE
[DOC] Extend x-axis on demo.ipynb plot, remove log statements to console

### DIFF
--- a/amocarray/logger.py
+++ b/amocarray/logger.py
@@ -90,6 +90,6 @@ def setup_logger(array_name: str, output_dir: str = "logs") -> None:
         log.handlers.clear()
 
         log.addHandler(file_handler)
-        log.addHandler(console_handler)
+        # log.addHandler(console_handler)
 
         log.info(f"Logger initialized for array: {array_name}, writing to {log_path}")

--- a/amocarray/plotters.py
+++ b/amocarray/plotters.py
@@ -485,7 +485,7 @@ def plot_monthly_anomalies(
     for ax in axes:
         ax.spines["top"].set_visible(False)
         ax.spines["right"].set_visible(False)
-        ax.set_xlim([pd.Timestamp("2000-01-01"), pd.Timestamp("2022-12-31")])
+        ax.set_xlim([pd.Timestamp("2000-01-01"), pd.Timestamp("2023-12-31")])
         ax.set_clip_on(False)
         ax.set_yticks(range(int(ax.get_ylim()[0]) + 1, int(ax.get_ylim()[1]) + 1, 5))
     axes[0].set_ylim([5, 25])  # OSNAP


### PR DESCRIPTION
## [DOC] Extend x-axis for RAPID extension (to 2023-02-11) and remove log statements in demo.ipynb

**Description:**

- Extend `plotters.plot_monthly_anomalies()` from ending in 2022-12-31 to 2023-12-31
- Turn off log statements in console (to have a cleaner `demo.ipynb` run)

**Checklist:**

- [x] I have followed the [coding conventions](https://amoccommunity.github.io/amocarray/conventions.html).
- [ ] I have updated or added tests to cover my changes.
- [ ] I have updated the documentation if needed.
- [x] I have run `pytest` to check that all tests pass.
- [x] I have run `pre-commit run --all-files` to lint and format the code.

**Related Issues / Pull Requests:**

Link any related issues, pull requests, or discussions:
- Related to #45 
