### PR TITLE
[FEAT] Add metadata for new rapid dataset, Issue #45

### DIFF
--- a/amocarray/read_rapid.py
+++ b/amocarray/read_rapid.py
@@ -43,11 +43,15 @@ RAPID_FILE_METADATA = {
     "2d_gridded.nc": {
         "data_product": "RAPID 2D gridded temperature and salinity",
     },
+    "meridional_transports.nc": {
+        "data_product": "RAPID meridional transport time series",
+    },
 }
 # https://rapid.ac.uk/sites/default/files/rapid_data/ts_gridded.nc
 # https://rapid.ac.uk/sites/default/files/rapid_data/moc_vertical.nc
 # https://rapid.ac.uk/sites/default/files/rapid_data/moc_transports.nc
-
+# https://rapid.ac.uk/sites/default/files/rapid_data/2d_gridded.nc
+# https://rapid.ac.uk/sites/default/files/rapid_data/meridional_transports.nc
 
 @apply_defaults(RAPID_DEFAULT_SOURCE, RAPID_DEFAULT_FILES)
 def read_rapid(

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -87,7 +87,7 @@
     "# Plot RAPID timeseries\n",
     "\n",
     "plotters.plot_amoc_timeseries(\n",
-    "    data=[standardRAPID[0]], # standardRAPID[2] is the same file which was loaded into ds_rapid via the quick start way (see above)\n",
+    "    data=[standardRAPID[0]],\n",
     "    varnames=[\"moc_mar_hc10\"],\n",
     "    labels=[\"\"],\n",
     "    resample_monthly=True,\n",


### PR DESCRIPTION
I didn't see that you already changed the default files to hold all the new rapid files, so I just added the metadata for `meridional_transports.nc` and the origin URLs for the new datasets.