### PR TITLE
[FIX] fix x label in monthly_anomalies

### DIFF
--- a/amocarray/plotters.py
+++ b/amocarray/plotters.py
@@ -482,7 +482,6 @@ def plot_monthly_anomalies(
     axes[3].plot(samba_data["TIME"], samba_data, color="purple", label=samba_label)
     axes[3].axhline(0, color="black", linestyle="--", linewidth=0.5)
     axes[3].set_title(samba_label)
-    axes[3].set_xlabel("Time")
     axes[3].set_ylabel("Transport [Sv]")
     axes[3].legend()
     axes[3].grid(True, linestyle="--", alpha=0.5)


### PR DESCRIPTION
## [FIX] fix x label in monthly_anomalies

**Description:**
Remove the extra label on the fourth plot

**Related Issues / Pull Requests:**

- Fixes #59 


