### PR TITLE
[DOCS] Reorder the documentation pages to bring demo notebook towards the top

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,14 +12,14 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
 
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Getting started
 
    installation.md
 
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Demo notebook
 
    demo-output.ipynb
@@ -27,7 +27,7 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
 
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Data format
 
    format_orig
@@ -36,7 +36,7 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
    format_AC1
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Help and reference
 
    GitHub Repo <http://github.com/AMOCcommunity/amocarray>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,23 +17,14 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
 
    installation.md
 
-.. toctree::
-   :maxdepth: 3
-   :caption: Developers' guide
-
-   developer_guide.md
-   gitcollab.md
-   actions.md
-   conventions.md
-   housekeeping.md
 
 .. toctree::
    :maxdepth: 3
-   :caption: Vocabularies
+   :caption: Demo notebook
 
-   AC1_vocabularies
-   AC1_units
-   AC1_variables
+   demo-output.ipynb
+
+
 
 .. toctree::
    :maxdepth: 3
@@ -46,17 +37,23 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
 
 .. toctree::
    :maxdepth: 3
-   :caption: Demo notebook
-
-   demo-output.ipynb
-
-
-.. toctree::
-   :maxdepth: 3
    :caption: Help and reference
 
    GitHub Repo <http://github.com/AMOCcommunity/amocarray>
    amocarray
+   AC1_vocabularies
+   AC1_units
+   AC1_variables
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Developers' guide
+
+   developer_guide.md
+   gitcollab.md
+   actions.md
+   conventions.md
+   housekeeping.md
 
 Indices and tables
 ==================

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -18,13 +18,16 @@ cd amocarray
 pip install -r requirements-dev.txt
 pip install -e .
 ```
-This installs amocarray locally.  The `-e` ensures that any edits you make in the files will be picked up by scripts that impport functions from glidertest.
+This installs amocarray locally.  The `-e` ensures that any edits you make in the files will be picked up by scripts that impport functions from glidertest.  The `requirements-dev.txt` includes more python packages which are needed development, including to build this documentation page, run tests, or run linting (formatting checks on your code).
 
 You can run the example jupyter notebook by launching jupyterlab with `jupyter-lab` and navigating to the `notebooks` directory, or in VS Code or another python GUI.
 
-All new functions should include tests.  You can run tests locally and generate a coverage reporrt with:
+All new functions should include tests.  You can run tests locally and generate a coverage report with:
 ```sh
 pytest --cov=amocarray --cov-report term-missing tests/
 ```
+This tells you what lines of a module (e.g., `amocarray/readers.py`) are not run through during the existing tests (located in `tests/`).
 
 Try to ensure that all the lines of your contribution are covered in the tests.
+
+See also the [Developers Guide](developer_guide.md) for coding conventions used here (e.g., style of comments at the top of a function), the automatic "GitHub Actions" which are triggered when you make a pull request,  and an example workflow to use Git to collaborate on code.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -18,7 +18,7 @@ cd amocarray
 pip install -r requirements-dev.txt
 pip install -e .
 ```
-This installs amocarray locally.  The `-e` ensures that any edits you make in the files will be picked up by scripts that impport functions from glidertest.  The `requirements-dev.txt` includes more python packages which are needed development, including to build this documentation page, run tests, or run linting (formatting checks on your code).
+This installs amocarray locally.  The `-e` ensures that any edits you make in the files will be picked up by scripts that import functions from glidertest.  The `requirements-dev.txt` includes more python packages which are needed for development, including to build this documentation page, run tests, or run linting (formatting checks on your code).
 
 You can run the example jupyter notebook by launching jupyterlab with `jupyter-lab` and navigating to the `notebooks` directory, or in VS Code or another python GUI.
 


### PR DESCRIPTION
## [DOCS] Reorder docs, small edits

**Description:**

The documentation was too heavy on the "developer's guide".  This has now been moved to the bottom and the max depth of the table of contents reduced (except for the reference section, where it may be useful to more quickly pan through variables and function names instead of scroll).


**Checklist:**

- [ ] I have followed the [coding conventions](https://amoccommunity.github.io/amocarray/conventions.html).
- [ ] I have updated or added tests to cover my changes.
- [x] I have updated the documentation if needed.
- [ ] I have run `pytest` to check that all tests pass.
- [x] I have run `pre-commit run --all-files` to lint and format the code.

