### PR TITLE
[DOC] update conversion and cleanup

### DIFF
--- a/docs/source/AC1_units.rst
+++ b/docs/source/AC1_units.rst
@@ -11,7 +11,7 @@ SI base units (XML) are `here <https://docs.unidata.ucar.edu/udunits/current/udu
 
 Derived units (XML) are `here <https://docs.unidata.ucar.edu/udunits/current/udunits2-derived.xml>`_.
 
-Non-SI units including sverdrup, **where apparently we cannot use Sv because it also means "sievert" in the SI unit-system**.
+Non-SI units including Sverdrup (full spelling used to avoid confusion with "Sv" for sievert in the SI unit system).
 
 
 Variables
@@ -134,14 +134,12 @@ Transport Units
 +-------------------------+------------+-----------------------------+
 | Name                    | Symbol     | Definition                  |
 +=========================+============+=============================+
-| sverdrup,               | Sv*        | 1e6 m³/s                    |
-| **Sverdrup**            |            | alias for Sv                |
+| **Sverdrup**            | Sverdrup   | 1e6 m³/s                    |
+|                         |            | (full spelling preferred)   |
 +-------------------------+------------+-----------------------------+
 | cubic_meter_per_second  | m³/s,      | Ocean volume transport      |
 |                         | **m3 s-1** |                             |
 +-------------------------+------------+-----------------------------+
-
-***Not** recommended since it conflicts with SI "sievert".
 
 Energy and Power Units
 ~~~~~~~~~~~~~~~~~
@@ -200,12 +198,12 @@ Mapping of Custom Conversions
 +------------------+------------------+------------------+--------------------------+
 | g m-3            | kg m-3           | 0.001            | Density                  |
 +------------------+------------------+------------------+--------------------------+
-| Sverdrup         | Sv*              | 1                | Transport                |
+| Sverdrup         | Sverdrup         | 1                | Transport                |
 +------------------+------------------+------------------+--------------------------+
 | W, J             | watt, joule      | base units       | Energy and Power         |
 +------------------+------------------+------------------+--------------------------+
 
-***Not** recommended since it conflicts with SI "sievert".
+**Note:** Full "Sverdrup" spelling used to avoid confusion with "Sv" (sievert).
 
 
 SI Unit Prefixes

--- a/docs/source/AC1_vocabularies.rst
+++ b/docs/source/AC1_vocabularies.rst
@@ -365,7 +365,7 @@ ocean_volume_transport_across_line (TRANSPORT)
 **Description**: Volume transport across a specified line (e.g., a latitude section).
 
 - **CF Standard Name**: `ocean_volume_transport_across_line`
-- **Suggested Units**: `m³ s⁻¹`
+- **Suggested Units**: `m3 s-1`
 - **Vocabulary**: NERC P07 Concept ID W946809H
 - **Vocabulary (URI)**: http://vocab.nerc.ac.uk/collection/P07/current/W946809H/
 - **SeaDataNet Parameter**: [Insert if applicable]
@@ -380,7 +380,7 @@ ocean_meridional_overturning_streamfunction (MOC)
 **Description**: Net vertical and meridional circulation of the ocean, excluding parameterized eddy components.
 
 - **CF Standard Name**: `ocean_meridional_overturning_streamfunction`
-- **Suggested Units**: `m³ s⁻¹`
+- **Suggested Units**: `m3 s-1`
 - **Vocabulary**: NERC P07 Concept ID CFSN0466
 - **Vocabulary (URI)**: https://vocab.nerc.ac.uk/collection/P07/current/CFSN0466/
 - **SeaDataNet Parameter**: Not available
@@ -396,7 +396,7 @@ ocean_meridional_overturning_mass_streamfunction
 **Description**: Overturning streamfunction including all resolved and parameterized mass transport processes.
 
 - **CF Standard Name**: `ocean_meridional_overturning_mass_streamfunction`
-- **Suggested Units**: `kg s⁻¹`
+- **Suggested Units**: `kg s-1`
 - **Vocabulary**: NERC P07 Concept ID CF12N554
 - **Vocabulary (URI)**: http://vocab.nerc.ac.uk/collection/P07/current/CF12N554/
 - **SeaDataNet Parameter**: [Insert if applicable]
@@ -416,7 +416,7 @@ northward_ocean_freshwater_transport (FWT)
 **Description**: Total northward transport of freshwater.
 
 - **CF Standard Name**: `northward_ocean_freshwater_transport`
-- **Suggested Units**: `m³ s⁻¹` (often presented as Sv freshwater equivalents)
+- **Suggested Units**: `m3 s-1` (often presented as Sverdrup freshwater equivalents)
 - **Vocabulary**: NERC P07 Concept ID CFSN0507
 - **Vocabulary (URI)**: http://vocab.nerc.ac.uk/collection/P07/current/CFSN0507/
 - **SeaDataNet Parameter**: Not available
@@ -432,7 +432,7 @@ northward_ocean_freshwater_transport_due_to_overturning (FWT_OV)
 **Description**: Freshwater transport component associated with the overturning circulation.
 
 - **CF Standard Name**: `northward_ocean_freshwater_transport_due_to_overturning`
-- **Suggested Units**: `m³ s⁻¹` or `Sv freshwater equivalent`
+- **Suggested Units**: `m3 s-1` or `Sverdrup freshwater equivalent`
 - **Vocabulary**: NERC P07 Concept ID CFSN0482
 - **Vocabulary (URI)**: http://vocab.nerc.ac.uk/collection/P07/current/CFSN0482/
 - **SeaDataNet Parameter**: Not available
@@ -448,7 +448,7 @@ northward_ocean_freshwater_transport_due_to_gyre (FWT_GYRE)
 **Description**: Component of freshwater transport from horizontal gyre-scale circulation.
 
 - **CF Standard Name**: `northward_ocean_freshwater_transport_due_to_gyre`
-- **Suggested Units**: `m³ s⁻¹` or `Sv freshwater equivalent`
+- **Suggested Units**: `m3 s-1` or `Sverdrup freshwater equivalent`
 - **Vocabulary**: NERC P07 Concept ID CFSN0510
 - **Vocabulary (URI)**: http://vocab.nerc.ac.uk/collection/P07/current/CFSN0510/
 - **SeaDataNet Parameter**: Not available

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,0 +1,60 @@
+About AMOCarray
+===============
+
+What is this?
+-------------
+
+AMOCarray is a Python package for loading data from Atlantic Meridional Overturning Circulation (AMOC) observing arrays. It gives you a simple way to access data from different programmes around the Atlantic.
+
+Why AMOC?
+---------
+
+The Atlantic Meridional Overturning Circulation moves warm water north and cold water south in the Atlantic Ocean. It's important for climate - think of it as a giant conveyor belt that helps regulate temperatures in Europe and beyond.
+
+Scientists monitor this circulation at several locations using moorings and other instruments. AMOCarray makes it easier to work with data from these monitoring arrays.
+
+What arrays are included?
+-------------------------
+
+* **RAPID (26°N)** - The longest-running basin-wide array, monitoring since 2004
+* **MOVE (16°N)** - Tropical Atlantic monitoring, west of the Mid-Atlantic Ridge
+* **OSNAP (Subpolar)** - Covers the subpolar North Atlantic
+* **SAMBA (34.5°S)** - South Atlantic monitoring
+* **41°N** - Uses Argo float data and altimetry
+* **DSO** - Denmark Strait overflow
+* **RAPID/MOCHA** - Heat transport estimates from 26°N
+* **FW2015** - Altimetry-based transport estimates at 26°N
+
+What can you do with it?
+------------------------
+
+* Load data from any array of the above arrays (or measurement methods) with just a few lines of code
+* Compare data across different locations
+* Make plots with consistent styling
+* Access both sample datasets (for testing) and full datasets
+* Get detailed logs of what data was downloaded and processed
+
+The package handles downloading, caching, and organizing the data so you can focus on the science.  Note that if the web-based locations of the original datasets change, that links may break.  Please then raise an issue (see below) or try a fix yourself (see developer guide).
+
+Getting started
+---------------
+
+The quickest way to try it out::
+
+    from amocarray import readers
+
+    # Load a sample dataset
+    ds = readers.load_sample_dataset("rapid")
+    print(ds)
+
+Check out the demo notebook for more examples.
+
+Need help?
+----------
+
+* Full documentation: https://amoccommunity.github.io/amocarray
+* Issues and questions: https://github.com/AMOCcommunity/amocarray/issues
+* Contributing: See our developer guide
+
+.. note::
+   This project is supported by the Horizon Europe project EPOC - Explaining and Predicting the Ocean Conveyor.

--- a/docs/source/format_AC1.rst
+++ b/docs/source/format_AC1.rst
@@ -3,6 +3,13 @@ AMOCarray Format AC1
 
 This document defines the AC1 standard data format produced by the ``amocarray.convert.to_AC1()`` function.  This format is designed to provide consistency between moored estimates of overturning transport, as from the RAPID, OSNAP, MOVE and SAMBA arrays.
 
+**Relationship to Other Format Documents:**
+
+- :doc:`format_orig` - Documents native data formats from each array
+- :doc:`format_conversion` - Describes conversion strategies from native to standardized formats  
+- :doc:`format_oceanSITES` - Details OceanSITES compliance requirements
+- **This document (format_AC1)** - Specifies the final standardized output format
+
 1. Overview
 -----------
 
@@ -78,7 +85,7 @@ Note that CF-conventions (https://cfconventions.org/cf-conventions/cf-convention
      - S
    * - TRANSPORT
      - (TIME,)
-     - Sv
+     - Sverdrup
      - Overturning transport estimate
      - S
 
@@ -291,6 +298,11 @@ This function:
 ------------------------------
 
 To ensure transparency and appropriate credit to original data providers, the AC1 format includes structured global attributes for data provenance.
+
+**Project Funding:**
+AC1 format development is supported by the Horizon Europe project EPOC - Explaining and Predicting the Ocean Conveyor (Grant Agreement No. 101081012).
+
+*Funded by the European Union. Views and opinions expressed are however those of the author(s) only and do not necessarily reflect those of the European Union. Neither the European Union nor the granting authority can be held responsible for them.*
 
 Required Provenance Fields:
 

--- a/docs/source/format_convert_osnap.rst
+++ b/docs/source/format_convert_osnap.rst
@@ -17,7 +17,7 @@ Potential reformats:
 - **Overturning:**
   - ``MOC`` and ``MOC_ERR``: time series (dimension: ``TIME``, ``N_LOCATION``=3) where ``N_LOCATION``=3 (e.g. MOC_ALL, MOC_EAST, MOC_WEST)
 
-  - ``STREAMFUNCTION``: (``N_LEVELS``, ``TIME``, ``N_PROF``=3) - This would be from ``OSNAP_Streamfunction_201408_202006_2023.nc``and is the overturning streamfunction in sigma-theta coordinates.
+  - ``STREAMFUNCTION``: (``TIME``, ``N_LEVELS``, ``N_PROF``=3) - This would be from ``OSNAP_Streamfunction_201408_202006_2023.nc`` and is the overturning streamfunction in sigma-theta coordinates.
 
   - ``MHT`` and ``MHT_ERR``: same dimensions as ``MOC``
 

--- a/docs/source/format_convert_rapid.rst
+++ b/docs/source/format_convert_rapid.rst
@@ -14,11 +14,11 @@ Check CF conventions for standard names: https://github.com/cf-convention/vocabu
 
 - ``moc_vertical.nc``:
 
-  - **Convert to OceanSITES:** Here, we should change the dimension to all-caps ``DEPTH`` and ``TIME``.  Units on the streamfunction should be `sverdrup` to de-confliict with `Sv` for sievert. According to OceanSITES, the order of the variables should be  T, Z, Y, X, so the streamfunction should be (``TIME``, ``DEPTH``).  The filename should be something like ``OS_RAPID_YYYYMMDD-YYYYMMDD_DPR_moc_vertical.nc``. Here, we are using the ``OS`` prefix, ``RAPID`` as the PlatformCode, the date start and end for the DeploymentCode, and the data mode is ``DPR`` for derived product.  The additional text after is the original filename, ``moc_vertical.nc``.
+  - **Convert to OceanSITES:** Here, we should change the dimension to all-caps ``DEPTH`` and ``TIME``.  Units on the streamfunction should be `Sverdrup` (full spelling to avoid confusion with `Sv` for sievert). According to OceanSITES, the order of the variables should be T, Z, Y, X, so the streamfunction should be (``TIME``, ``DEPTH``).  The filename should be something like ``OS_RAPID_YYYYMMDD-YYYYMMDD_DPR_mocvertical_T12H.nc``. Here, we are using the ``OS`` prefix, ``RAPID`` as the PlatformCode, the date start and end for the DeploymentCode, and the data mode is ``DPR`` for derived product.  The PARTX field combines the content type and time resolution.
 
 - ``ts_gridded.nc``:
 
-- **Convert to OceanSITES:** Dimensions should be ``TIME`` and ``DEPTH``, where the coordinate name can be ``PRES`` for ``pressure``.  The featureType global attribute can be ``timeSeriesProfile``.
+- **Convert to OceanSITES:** Dimensions should be ``TIME`` and ``DEPTH`` (in T, Z order), where the coordinate name can be ``PRES`` for ``pressure``.  The featureType global attribute can be ``timeSeriesProfile``.
 
 - ``moc_transports.nc``:
 
@@ -34,11 +34,11 @@ Potential reformats:
 - **Overturning:**
   - ``MOC``: time series (dimension: ``TIME``)
 
-  - ``STREAMFUNCTION``: (``DEPTH``, ``TIME``) - this is the vertical profile of MOC (originally ``stream_function_mar`` in ``moc_vertical.nc``, note that this extends deeper than the depth grid in ``ts_gridded.nc`` due to the incorporation of an AABW profile).
+  - ``STREAMFUNCTION``: (``TIME``, ``DEPTH``) - this is the vertical profile of MOC (originally ``stream_function_mar`` in ``moc_vertical.nc``, note that this extends deeper than the depth grid in ``ts_gridded.nc`` due to the incorporation of an AABW profile).
 
 - **Profiles:** ``TEMPERATURE``, ``SALINITY``, vertically gridded at mooring locations.
 
-  - Dimensions: ``TIME``, ``N_PROF``, ``N_LEVELS`` (242,1)
+  - Dimensions: ``TIME``, ``N_PROF``, ``N_LEVELS`` (T, Y/X, Z order)
 
   - Coordinates: ``LATITUDE``, ``LONGITUDE`` (``N_PROF``=5,) - these would be the locations of the profiles, which are current in the "long name" for each of the ``TG_west``, ``TG_east``, ``TG_wb3``, ``TG_MARWEST``, ``TG_mareast``.  etc. ``TIME`` in datetime.  And ``PRESSURE`` (``N_LEVELS``,) - this is the depth grid in ``ts_gridded.nc``.
 
@@ -46,7 +46,7 @@ Potential reformats:
 
 - **Gridded sections:** ``TEMPERATURE``, ``SALINITY``, ``VELOCITY``
 
-  - Dimensions: ``TIME``, ``N_PROF``, ``N_LEVELS`` (13000, longitude grid, 242?)
+  - Dimensions: ``TIME``, ``N_PROF``, ``N_LEVELS`` (T, Y/X, Z order)
 
   - Coordinates: ``LATITUDE``, ``LONGITUDE`` (``N_PROF``=longitude grid,), ``TIME`` in datetime.  And ``PRESSURE`` (``N_LEVELS``,)
 
@@ -54,7 +54,7 @@ Potential reformats:
 
 - **Layer transports:**
 
-  - Dimensions: ``TIME``, ``N_LEVELS`` (13779, 5)
+  - Dimensions: ``TIME``, ``N_LEVELS`` (T, Z order)
 
   - Coordinates: ``LATITUDE``, ``LONGITUDE_BOUNDS`` (scalar, x2), ``TIME`` in datetime.  And ``DEPTH_BOUND`` (``N_LEVELS``, 2) - this would be the depth bounds for the transport layers.
 
@@ -62,7 +62,7 @@ Potential reformats:
 
 - **Component transports:**
 
-  - Dimensions: ``TIME``, ``N_COMPONENT`` (13779, 5)
+  - Dimensions: ``TIME``, ``N_COMPONENT`` (T, component order)
 
   - Coordinates: ``LATITUDE``, ``LONGITUDE_BOUNDS`` (scalar, x2), ``TIME`` in datetime.  ``N_COMPONENT`` for the number of components.
 

--- a/docs/source/format_oceanSITES.rst
+++ b/docs/source/format_oceanSITES.rst
@@ -42,7 +42,7 @@ File naming for array data products
 
   - RAPID (PSPANCode = RAPID):
     - `ts_gridded.nc` has individual locations with timeSeriesProfile.  The `PARTX` for OceanSITES will be `gridded_mooring`, and ContentType = GRD.
-    - `moc_vertial.nc` and `moc_transports.nc` have the streamfunction, and time series of component transports at 12-hour intervals.  The `PARTX` for OceanSITES will combine both and this will be `transports_T12H.nc`, and ContentType = DPR.
+    - `moc_vertical.nc` and `moc_transports.nc` have the streamfunction, and time series of component transports at 12-hour intervals.  The `PARTX` for OceanSITES will combine both and this will be `transports_T12H.nc`, and ContentType = DPR.
     - `2d_gridded.nc` has the 2D gridded data.  The `PARTX` for OceanSITES will be `sections_T10D` for monthly, and ContentType = GRD.
     - `meridional_transports.nc` has the MOC transport in depth and sigma coordinates, as well as MHT and MFT on a 10-day grid. The `PARTX` for OceanSITES will be `transports_T10D.nc`, and ContentType = DPR.
 
@@ -373,8 +373,8 @@ The following attributes are recommended for inclusion in all OceanSITES-complia
      - RS
    * - ``publisher_name``
      - Name of the person responsible for metadata and formatting
-     - **ex.:** http://github.com/AMOCcommunity/amocarray
-     - **S**
+     - **ex.:** "AMOCarray Development Team"
+     - *S*
    * - ``publisher_url``
      - Web address of the institution or data publisher
      - **ex.:** "http://github.com/AMOCcommunity/amocarray"
@@ -422,7 +422,7 @@ The following attributes are recommended for inclusion in all OceanSITES-complia
      - *S*
    * - ``history``
      - Provides an audit trail for modifications to the original data. It should contain a separate line for each modification, with each line beginning with a timestamp, and including user name, modification name, and modification arguments. The time stamp should follow the format outlined in the note on time formats below. (NUG)
-     - **ex.:** history= “2012-04-11T08:35:00Z data collected, A. Meyer;
+     - **ex.:** history= "2012-04-11T08:35:00Z data collected, A. Meyer; 2012-04-12T10:15:00Z quality control applied, B. Smith"
      - *S*
    * - ``processing_level``
      - Level of processing and quality control applied to data. Preferred values are listed in reference table 3.

--- a/docs/source/format_orig.rst
+++ b/docs/source/format_orig.rst
@@ -14,6 +14,8 @@ In the logic of `amocarray`, we will first convert to an OceanSITES compatible f
 - :ref:`OSNAP <array-osnap>`
 - :ref:`MOVE <array-move>`
 - :ref:`SAMBA <array-samba>`
+- :ref:`41°N <array-41n>`
+- :ref:`DSO <array-dso>`
 - :ref:`FW2015 <array-fw2015>`
 - :ref:`MOCHA <array-mocha>`
 
@@ -22,103 +24,7 @@ In the logic of `amocarray`, we will first convert to an OceanSITES compatible f
 .. include:: format_orig_rapid.rst
 .. include:: format_orig_move.rst
 .. include:: format_orig_samba.rst
-
-.. _array-fw2015:
-
-FW2015
--------
-
-This is a different beast but similar to RAPID in that it has components which represent transport for different segments of the array (like Gulf Stream, Ekman and upper-mid-ocean) where these sum to produce MOC.  This is *vaguely* like OSNAP east and OSNAP west, except I don't think those sum to produce the total overturning.  And Ekman could be part of a layer transport but here is has no depth reference.  Gulf Stream has longitude bounds and a single latitude (``LATITUDE``, ``LONGITUDE_BOUND``) and limits over which the depths are represented (``DEPTH_BOUND``?) but no N_LEVELS.  It doesn't quite make sense to call the dimension N_PROF since these aren't profiles.  Maybe **N_COMPONENT**?
-
-
-Summary of FW2015 files:
-~~~~~~~~~~~~~~~~~~~~~~~~~~`
-- ``MOCproxy_for_figshare_v1.mat``
-
-  - ``TIME``: dimension ``TIME`` (264,), type datetime
-
-  - ``MOC_PROXY``: dimension ``TIME``, units `Sv`
-
-  - ``EK``: dimension ``TIME``, units `Sv`
-
-  - ``GS``: dimension ``TIME``, units `Sv`
-
-  - ``UMO_PROXY``: dimension ``TIME``, units `Sv`
-
-Potential reformats:
-~~~~~~~~~~~~~~~~~~~~~~~~~~`
-
-- **Overturning:**
-
-  - ``MOC``: time series (dimension: ``TIME``)
-
-- **Component transports:**
-
-  - Dimensions: ``TIME``, ``N_COMPONENT`` (1404, 7)
-
-  - Coordinates: ``LATITUDE``, ``LONGITUDE_BOUNDS`` (scalar, x2), ``TIME`` in datetime.  ``N_COMPONENT`` for the number of components.
-
-  - Variables: ``TRANSPORT`` (``TIME``, ``N_COMPONENT``) -  This would also have ``TRANSPORT_NAME`` (``N_COMPONENT``, string) to indicate what the component is (e.g. `EK`, `GS`, `LNADW`, `MOC`, `MOC_PROXY`, `UMO_GRID`, `UMO_PROXY`, `UNADW_GRID`, etc).  Note that some of these were just copies of what the RAPID time series was at the time.
-
-
-
-
-
-.. _array-mocha:
-
-MOCHA
------
-
-
-Summary of MOCHA files:
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-The heat transports at RAPID-MOCHA are provided with N_LEVELS, TIME, and variables:
-
-- Q_eddy
-
-- Q_ek
-
-- Q_fc
-
-- Q_gyre
-
-- Q_int.
-
-Again, we have a situation where N_PROF isn't really appropriate.  Maybe **N_COMPONENT**?  WE should double check that things called **N_COMPONENT** then somehow sum to produce a total?  Then we would have something like MHT_COMPONENTS (``N_COMPONENT``, ``TIME``) and MHT (``TIME``)
-
-But we also have things like:
-
-- T_basin (``TIME``, ``N_LEVELS``)
-
-- T_basin_mean (``N_LEVELS``)
-
-- T_fc_fwt (``TIME``)
-
-- V_basin (``TIME``, ``N_LEVELS``) --> is this identical to new RAPID velo sxn?
-
-- V_basin_mean (``N_LEVELS``)
-
-- V_fc (``TIME``, ``N_LEVELS``)
-
-
-Potential reformats:
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-So this might be suggested as a TEMPERATURE (``TIME``, ``N_LEVELS``) but unclear how to indicate that this is a zonal mean temperature as compared to the ones which are TEMPERATURE (``N_PROF``, ``TIME``, ``N_LEVELS``) for the full sections.
-
-
-- **Heat Transport Components**:
-
-  - `Q_eddy`, `Q_ek`, `Q_fc`, `Q_gyre`, `Q_int` → suggest ``MHT_COMPONENT`` (``N_COMPONENT``, ``TIME``)
-
-  - Total: ``MHT`` (``TIME``)
-
-- **Additional Variables**:
-
-  - `T_basin`, `V_basin`, `T_fc_fwt`, etc.
-
-  - These suggest basin-mean properties: ``TEMPERATURE`` (``TIME``, ``N_LEVELS``)
-
-- **Note**: ``N_COMPONENT`` should indicate summable components if applicable
-
-
+.. include:: format_orig_41n.rst
+.. include:: format_orig_dso.rst
+.. include:: format_orig_fw2015.rst
+.. include:: format_orig_mocha.rst

--- a/docs/source/format_orig_41n.rst
+++ b/docs/source/format_orig_41n.rst
@@ -1,0 +1,59 @@
+.. This file is included under 'format_orig.rst' and should use '~~' or lower as the top header level.
+
+.. _array-41n:
+
+41°N Original Data Format
+-------------------------
+
+The 41°N array provides AMOC estimates derived from Argo float observations and satellite altimetry data, extending the observational record back to 2002.
+
+.. note::
+   **Documentation stub**: This section needs to be completed with detailed format specifications.
+   
+   See GitHub issue for 41°N data format documentation.
+
+hobbs_willis_amoc41N_tseries.txt
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This dataset contains monthly time series of AMOC transport estimates at 41°N.
+
+.. list-table:: Variables (preliminary)
+   :widths: 12 22 14 10 35
+   :header-rows: 1
+
+   * - Name
+     - Dimensions
+     - Shape
+     - Units
+     - Description
+   * - ``TIME``
+     - ``TIME``
+     - (TBD,)
+     - datetime
+     - Time coordinate
+   * - ``EKMAN``
+     - ``TIME``
+     - (TBD,)
+     - Sv
+     - Ekman volume transport
+   * - ``V_GEOS``
+     - ``TIME``
+     - (TBD,)
+     - Sv
+     - Northward geostrophic transport
+   * - ``MOT``
+     - ``TIME``
+     - (TBD,)
+     - Sv
+     - Meridional overturning volume transport
+   * - ``MOHT``
+     - ``TIME``
+     - (TBD,)
+     - PW
+     - Meridional overturning heat transport
+
+.. todo::
+   - Complete data format specifications
+   - Add detailed variable descriptions
+   - Document data processing methodology
+   - Add references to Hobbs & Willis methodology

--- a/docs/source/format_orig_dso.rst
+++ b/docs/source/format_orig_dso.rst
@@ -1,0 +1,46 @@
+.. This file is included under 'format_orig.rst' and should use '~~' or lower as the top header level.
+
+.. _array-dso:
+
+DSO Original Data Format
+------------------------
+
+The Denmark Strait Overflow (DSO) monitoring provides continuous time series of dense water overflow transport through Denmark Strait, a critical component of the Atlantic meridional overturning circulation.
+
+.. note::
+   **Documentation stub**: This section needs to be completed with detailed format specifications.
+   
+   See GitHub issue for DSO data format documentation.
+
+DSO_transport_hourly_1996_2021.nc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This dataset contains hourly time series of Denmark Strait overflow transport from 1996 to 2021.
+
+.. list-table:: Variables (preliminary)
+   :widths: 12 22 14 10 35
+   :header-rows: 1
+
+   * - Name
+     - Dimensions
+     - Shape
+     - Units
+     - Description
+   * - ``time``
+     - ``time``
+     - (TBD,)
+     - datetime
+     - Time coordinate (hourly)
+   * - ``DSO``
+     - ``time``
+     - (TBD,)
+     - Sv
+     - Denmark Strait overflow volume transport
+
+.. todo::
+   - Complete data format specifications
+   - Add detailed variable descriptions
+   - Document overflow monitoring methodology
+   - Add references to Hamburg/Reykjavik collaboration
+   - Document quality control procedures
+   - Add information about mooring array configuration

--- a/docs/source/format_orig_fw2015.rst
+++ b/docs/source/format_orig_fw2015.rst
@@ -1,0 +1,37 @@
+.. This file is included under 'format_orig.rst' and should use '~~' or lower as the top header level.
+
+.. _array-fw2015:
+
+FW2015 Original Data Format
+---------------------------
+
+This is a different beast but similar to RAPID in that it has components which represent transport for different segments of the array (like Gulf Stream, Ekman and upper-mid-ocean) where these sum to produce MOC. This is *vaguely* like OSNAP east and OSNAP west, except I don't think those sum to produce the total overturning. And Ekman could be part of a layer transport but here is has no depth reference. Gulf Stream has longitude bounds and a single latitude (``LATITUDE``, ``LONGITUDE_BOUND``) and limits over which the depths are represented (``DEPTH_BOUND``?) but no N_LEVELS. It doesn't quite make sense to call the dimension N_PROF since these aren't profiles. Maybe **N_COMPONENT**?
+
+Summary of FW2015 files:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``MOCproxy_for_figshare_v1.mat``
+
+  - ``TIME``: dimension ``TIME`` (264,), type datetime
+
+  - ``MOC_PROXY``: dimension ``TIME``, units `Sv`
+
+  - ``EK``: dimension ``TIME``, units `Sv`
+
+  - ``GS``: dimension ``TIME``, units `Sv`
+
+  - ``UMO_PROXY``: dimension ``TIME``, units `Sv`
+
+Potential reformats:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Overturning:**
+
+  - ``MOC``: time series (dimension: ``TIME``)
+
+- **Component transports:**
+
+  - Dimensions: ``TIME``, ``N_COMPONENT`` (1404, 7)
+
+  - Coordinates: ``LATITUDE``, ``LONGITUDE_BOUNDS`` (scalar, x2), ``TIME`` in datetime. ``N_COMPONENT`` for the number of components.
+
+  - Variables: ``TRANSPORT`` (``TIME``, ``N_COMPONENT``) - This would also have ``TRANSPORT_NAME`` (``N_COMPONENT``, string) to indicate what the component is (e.g. `EK`, `GS`, `LNADW`, `MOC`, `MOC_PROXY`, `UMO_GRID`, `UMO_PROXY`, `UNADW_GRID`, etc). Note that some of these were just copies of what the RAPID time series was at the time.

--- a/docs/source/format_orig_mocha.rst
+++ b/docs/source/format_orig_mocha.rst
@@ -1,0 +1,57 @@
+.. This file is included under 'format_orig.rst' and should use '~~' or lower as the top header level.
+
+.. _array-mocha:
+
+MOCHA Original Data Format
+--------------------------
+
+Summary of MOCHA files:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The heat transports at RAPID-MOCHA are provided with N_LEVELS, TIME, and variables:
+
+- Q_eddy
+
+- Q_ek
+
+- Q_fc
+
+- Q_gyre
+
+- Q_int.
+
+Again, we have a situation where N_PROF isn't really appropriate. Maybe **N_COMPONENT**? WE should double check that things called **N_COMPONENT** then somehow sum to produce a total? Then we would have something like MHT_COMPONENTS (``N_COMPONENT``, ``TIME``) and MHT (``TIME``)
+
+But we also have things like:
+
+- T_basin (``TIME``, ``N_LEVELS``)
+
+- T_basin_mean (``N_LEVELS``)
+
+- T_fc_fwt (``TIME``)
+
+- V_basin (``TIME``, ``N_LEVELS``) --> is this identical to new RAPID velo sxn?
+
+- V_basin_mean (``N_LEVELS``)
+
+- V_fc (``TIME``, ``N_LEVELS``)
+
+
+Potential reformats:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+So this might be suggested as a TEMPERATURE (``TIME``, ``N_LEVELS``) but unclear how to indicate that this is a zonal mean temperature as compared to the ones which are TEMPERATURE (``N_PROF``, ``TIME``, ``N_LEVELS``) for the full sections.
+
+
+- **Heat Transport Components**:
+
+  - `Q_eddy`, `Q_ek`, `Q_fc`, `Q_gyre`, `Q_int` → suggest ``MHT_COMPONENT`` (``N_COMPONENT``, ``TIME``)
+
+  - Total: ``MHT`` (``TIME``)
+
+- **Additional Variables**:
+
+  - `T_basin`, `V_basin`, `T_fc_fwt`, etc.
+
+  - These suggest basin-mean properties: ``TEMPERATURE`` (``TIME``, ``N_LEVELS``)
+
+- **Note**: ``N_COMPONENT`` should indicate summable components if applicable

--- a/docs/source/format_orig_move.rst
+++ b/docs/source/format_orig_move.rst
@@ -1,7 +1,9 @@
 .. This file is included under 'format_orig.rst' and should use '~~' or lower as the top header level.
 
+.. _array-move:
+
 MOVE Original Data Format
-----------------------
+-------------------------
 
 MOVE provides the TRANSPORT_TOTAL which corresponds to the MOC, but also things like transport_component_internal (``TIME``,), transport_component_internal_offset (``TIME``,), and transport_component_boundary (``TIME``,).  This would be similar to RAPID's version of "interior transport" and "western boundary wedge", but it's not so clear how to make these similarly named.
 

--- a/docs/source/format_overview.rst
+++ b/docs/source/format_overview.rst
@@ -1,0 +1,81 @@
+Data Format Documentation Overview
+===================================
+
+This section contains documentation about data formats used in AMOCarray. The documentation is organized to follow the data processing workflow from native formats to standardized outputs.
+
+Understanding the Documentation Structure
+-----------------------------------------
+
+The data format documentation is organized around four key stages of data handling:
+
+.. list-table:: Documentation Organization
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Document
+     - Purpose
+     - When to Use
+   * - :doc:`format_orig`
+     - **Native formats** from observing arrays
+     - Understanding original data structure from each array (RAPID, OSNAP, etc.)
+   * - :doc:`format_oceanSITES`  
+     - **Standards compliance** requirements
+     - Implementing OceanSITES-compliant data formats
+   * - :doc:`format_conversion`
+     - **Conversion strategies** from native to standard
+     - Planning how to transform native formats to standardized ones
+   * - :doc:`format_AC1`
+     - **Final standardized format** specification
+     - Using ``amocarray.convert.to_AC1()`` function output
+
+Workflow Overview
+-----------------
+
+The typical data processing workflow follows this sequence:
+
+1. **Original Data** → Each observing array provides data in its own native format
+2. **Analysis & Planning** → Understand native formats and plan conversions  
+3. **Standardization** → Convert to OceanSITES-compliant intermediate format
+4. **Final Output** → Produce AC1 standardized format for interoperability
+
+.. code-block:: text
+
+   Native Formats     Conversion       OceanSITES        AC1 Format
+   (format_orig) →  (format_conversion) → (format_oceanSITES) → (format_AC1)
+   
+   RAPID.nc                                                    
+   OSNAP.nc        →  Analysis &     →  Standards      →     Standardized
+   MOVE.nc            Planning          Compliance            Output
+   SAMBA.txt                                                  
+
+Key Concepts
+------------
+
+**Array Independence**
+   Each observing array (RAPID, OSNAP, MOVE, SAMBA, etc.) provides data in different formats, units, and structures. The native format documentation captures these differences.
+
+**Standards Compliance**
+   OceanSITES provides community standards for oceanographic data. We follow these conventions while adapting them for AMOC array requirements.
+
+**Unified Access**
+   The AC1 format provides a consistent interface regardless of which array the data originally came from, enabling cross-array analysis and comparison.
+
+**Metadata Preservation**
+   Throughout the conversion process, we preserve attribution to original data providers and maintain full provenance tracking.
+
+Getting Started
+---------------
+
+- **New to the project?** Start with :doc:`format_orig` to understand the data landscape
+- **Implementing readers?** Use :doc:`format_conversion` for conversion strategies  
+- **Need standards compliance?** Refer to :doc:`format_oceanSITES` for requirements
+- **Using converted data?** See :doc:`format_AC1` for the final format specification
+
+Questions and Contributions
+----------------------------
+
+If you have questions about data formats or want to contribute to format development:
+
+- Check our `GitHub issues <https://github.com/AMOCcommunity/amocarray/issues>`_
+- See the :doc:`developer_guide` for contribution guidelines
+- Review existing format documentation for similar arrays before proposing new formats

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
    :maxdepth: 2
    :caption: Getting started
 
+   about
    installation.md
 
 
@@ -30,6 +31,7 @@ For recommendations or bug reports, please visit https://github.com/AMOCcommunit
    :maxdepth: 2
    :caption: Data format
 
+   format_overview
    format_orig
    format_oceanSITES
    format_conversion


### PR DESCRIPTION
## Description:

 This PR improves consistency in documentation for format specifications.

### Documentation Structure Improvements

  Added format documentation overview
  - Created `format_overview.rst` to explain the relationship between different format documents
  - Added clear workflow explanation: native → conversion → OceanSITES → AC1

  Reorganized `format_orig` documentation
  - Split FW2015 and MOCHA content into separate files (`format_orig_fw2015.rst`, `format_orig_mocha.rst`)
  - Created stub files for missing arrays (41°N, DSO) with proper structure
  - Fixed missing reference labels and include statements
  - Cleaned up duplicated content in main file

### Standards Consistency Fixes

  Units standardization
  - Standardized all transport units to use full "Sverdrup" spelling (avoiding "Sv" confusion with sievert)
  - Updated CF notation to use standard format: m3 s-1, kg s-1 instead of Unicode superscripts
  - Consistent degree_Celsius usage throughout

###  OceanSITES compliance improvements
  - Fixed filename convention examples to match OceanSITES PARTX pattern
  - Corrected dimension ordering to follow T,Z,Y,X convention
  - Fixed formatting inconsistencies and typos

###  EPOC funding acknowledgment
  - Added proper EPOC project acknowledgment with Grant Agreement number
  - Included required EU disclaimer text
  - Added EPOC logo 