### PR TITLE
[FIX] Download SAMBA data

### DIFF
--- a/amocatlas/read_samba.py
+++ b/amocatlas/read_samba.py
@@ -21,7 +21,7 @@ SAMBA_TRANSPORT_FILES = [
 ]
 # Mapping of filenames to remote URLs
 SAMBA_FILE_URLS = {
-    "Upper_Abyssal_Transport_Anomalies.txt": "ftp://ftp.aoml.noaa.gov/phod/pub/SAM/2020_Kersale_etal_ScienceAdvances/",
+    "Upper_Abyssal_Transport_Anomalies.txt": "ftp://ftp.aoml.noaa.gov/phod/pub/SAM/2020_Kersale_etal_ScienceAdvances/Upper_Abyssal_Transport_Anomalies.txt",
     "MOC_TotalAnomaly_and_constituents.asc": "https://www.aoml.noaa.gov/phod/SAMOC_international/documents/MOC_TotalAnomaly_and_constituents.asc",
 }
 


### PR DESCRIPTION
**Description:**

Changed the  `read_sampa.py` so it correctly selects the SAMBA data from Meinen et al. via [https://www.aoml.noaa.gov/phod/SAMOC_international/documents/MOC_TotalAnomaly_and_constituents.asc](url) and Kersale et al. [ftp://ftp.aoml.noaa.gov/phod/pub/SAM/2020_Kersale_etal_ScienceAdvances/Upper_Abyssal_Transport_Anomalies.txt](url) by adding the filenames to the download URLs inside `read_samba.py`

**Related Issues / Pull Requests:**

- Fixes #92