### PR TITLE
[FEAT] New reader for AXMOC 22.5°S and 34.5°S

### DIFF
--- a/amocatlas/data_sources/__init__.py
+++ b/amocatlas/data_sources/__init__.py
@@ -30,6 +30,8 @@ from .noac47n import read_47n
 from .nac import read_nac
 from .sf2021 import read_sf2021
 from .lebras35n import read_lebras35n
+from .axmoc22s import read_axmoc22s
+from .axmoc34s import read_axmoc34s
 
 __all__ = [
     "read_rapid",
@@ -49,4 +51,6 @@ __all__ = [
     "read_nac",
     "read_sf2021",
     "read_lebras35n",
+    "read_axmoc22s",
+    "read_axmoc34s",
 ]

--- a/amocatlas/data_sources/axmoc22s.py
+++ b/amocatlas/data_sources/axmoc22s.py
@@ -5,10 +5,10 @@ This module provides functions to read and process AMOC and meridional heat tran
 Dataset includes estimates of AMOC and heat transport at 22.5°S. Both also have the Ekman and geostrophic component available.
 
 Key functions:
-- read_axmoc22s(): Main data loading interface for AMOC transport data at 22.5°S which includes both datasets
+- read_axmoc22s(): Main data loading interface for AMOC and meridional heat transport data at 22.5°S
 
 Data source: AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations
-Location: North Atlantic at 22.5°S
+Location: South Atlantic at 22.5°S
 """
 
 from pathlib import Path

--- a/amocatlas/data_sources/axmoc22s.py
+++ b/amocatlas/data_sources/axmoc22s.py
@@ -1,0 +1,184 @@
+"""AMOC at 22.5°S transport data reader for AMOCatlas.
+
+This module provides functions to read and process AMOC and meridional heat transport data at 22.5°S based on sustained in situ observations.
+
+Dataset includes estimates of AMOC and heat transport at 22.5°S. Both also have the Ekman and geostrophic component available.
+
+Key functions:
+- read_axmoc22s(): Main data loading interface for AMOC transport data at 22.5°S which includes both datasets
+
+Data source: AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations
+Location: North Atlantic at 22.5°S
+"""
+
+from pathlib import Path
+from typing import Union
+
+import xarray as xr
+
+# Import the modules used
+from amocatlas import logger, utilities
+from amocatlas.logger import log_error, log_info, log_warning
+from amocatlas.utilities import apply_defaults
+from amocatlas.reader_utils import ReaderUtils
+
+log = logger.log  # Use the global logger
+
+# Datasource identifier for automatic standardization
+DATASOURCE_ID = "axmoc22s"
+
+# Default list of AXMOC22S data files
+AXMOC22S_DEFAULT_FILES = ["AXMOC_22S_timeseries_2007_2023.nc"]
+AXMOC22S_TRANSPORT_FILES = ["AXMOC_22S_timeseries_2007_2023.nc"]
+AXMOC22S_DEFAULT_SOURCE = "https://zenodo.org/records/18839461/files/"
+
+AXMOC22S_METADATA = {
+    "project": "AMOC transport at 22.5S from sustained in situ observations",
+    "weblink": "https://zenodo.org/records/18839461",
+    "comment": "Dataset accessed and processed via http://github.com/AMOCcommunity/amocatlas",
+}
+
+AXMOC22S_FILE_METADATA = {
+    "AXMOC_22S_timeseries_2007_2023.nc": {
+        "data_product": "AMOC and MHT transport data at 22.5°S",
+    },
+}
+
+
+@apply_defaults(AXMOC22S_DEFAULT_SOURCE, AXMOC22S_DEFAULT_FILES)
+def read_axmoc22s(
+    source: Union[str, Path, None],
+    file_list: Union[str, list[str]],
+    transport_only: bool = True,
+    data_dir: Union[str, Path, None] = None,
+    redownload: bool = False,
+    track_added_attrs: bool = False,
+) -> list[xr.Dataset]:
+    """Load the AXMOC22S datasets from a URL or local file path into xarray Datasets.
+
+    Parameters
+    ----------
+    source : str, optional
+        Local path to the data directory (remote source is handled per-file).
+
+    file_list : str or list of str, optional
+        Filename or list of filenames to process.
+        Defaults to AXMOC22S_DEFAULT_FILES.
+
+    transport_only : bool, optional
+        If True, restrict to transport files only.
+
+    data_dir : str, Path or None, optional
+        Optional local data directory.
+
+    redownload : bool, optional
+        If True, force redownload of the data.
+    track_added_attrs : bool, optional
+        If True, track which attributes were added during metadata enrichment.
+
+    Returns
+    -------
+    list of xr.Dataset
+        List of loaded xarray datasets with basic inline and file-specific metadata.
+
+    Raises
+    ------
+    ValueError
+        If no source is provided for a file and no default URL mapping is found.
+
+    FileNotFoundError
+        If the file cannot be downloaded or does not exist locally.
+
+    """
+    log.info("Starting to read AXMOC22S dataset")
+
+    # Load YAML metadata with fallback
+    global_metadata, yaml_file_metadata = ReaderUtils.load_array_metadata_with_fallback(
+        DATASOURCE_ID, AXMOC22S_METADATA
+    )
+
+    # Ensure file_list has a default
+    if file_list is None:
+        file_list = AXMOC22S_DEFAULT_FILES
+    if transport_only:
+        file_list = AXMOC22S_TRANSPORT_FILES
+    if isinstance(file_list, str):
+        file_list = [file_list]
+    # Determine the local storage path
+    local_data_dir = Path(data_dir) if data_dir else utilities.get_default_data_dir()
+    local_data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Print information about files being loaded
+    ReaderUtils.print_loading_info(file_list, DATASOURCE_ID, AXMOC22S_FILE_METADATA)
+
+    datasets = []
+
+    added_attrs_per_dataset = [] if track_added_attrs else None
+    for file in file_list:
+        if not (file.lower().endswith(".nc")):
+            log_warning("Skipping unsupported file type : %s", file)
+            continue
+
+        download_url = (
+            f"{source.rstrip('/')}/{file}" if utilities.is_valid_url(source) else None
+        )
+
+        file_path = utilities.resolve_file_path(
+            file_name=file,
+            source=source,
+            download_url=download_url,
+            local_data_dir=local_data_dir,
+            redownload=redownload,
+        )
+
+        # Open dataset
+
+        if file.lower().endswith(".nc"):
+            # Use ReaderUtils for consistent dataset loading
+
+            ds = ReaderUtils.safe_load_dataset(file_path)
+            # Attach metadata
+            # Attach metadata with optional tracking
+
+            if track_added_attrs:
+                ds, attr_changes = ReaderUtils.attach_metadata_with_tracking(
+                    ds,
+                    file,
+                    file_path,
+                    global_metadata,
+                    yaml_file_metadata,
+                    AXMOC22S_FILE_METADATA,
+                    DATASOURCE_ID,
+                    track_added_attrs=True,
+                )
+
+                added_attrs_per_dataset.append(attr_changes)
+
+            else:
+                ds = ReaderUtils.attach_metadata_with_tracking(
+                    ds,
+                    file,
+                    file_path,
+                    global_metadata,
+                    yaml_file_metadata,
+                    AXMOC22S_FILE_METADATA,
+                    DATASOURCE_ID,
+                    track_added_attrs=False,
+                )
+        else:
+            raise ValueError(
+                f"Unsupported file type for {file}. Only .nc files are supported."
+            )
+
+        datasets.append(ds)
+
+    if not datasets:
+        log_error("No valid AXMOC22S files in %s", file_list)
+        raise FileNotFoundError(f"No valid data files found in {file_list}")
+
+    log_info("Successfully loaded %d AXMOC22S dataset(s)", len(datasets))
+
+    if track_added_attrs:
+        return datasets, added_attrs_per_dataset
+    else:
+        return datasets

--- a/amocatlas/data_sources/axmoc34s.py
+++ b/amocatlas/data_sources/axmoc34s.py
@@ -1,0 +1,184 @@
+"""AMOC at 34.5°S transport data reader for AMOCatlas.
+
+This module provides functions to read and process AMOC and meridional heat and freshwater transport data at 34.5°S based on sustained in situ observations.
+
+Dataset includes estimates of AMOC, heat and freshwatertransport at 34.5°S. All three also have the Ekman and geostrophic component available.
+
+Key functions:
+- read_axmoc34s(): Main data loading interface for AMOC transport data at 34.5°S which includes both datasets
+
+Data source: AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations
+Location: North Atlantic at 34.5°S
+"""
+
+from pathlib import Path
+from typing import Union
+
+import xarray as xr
+
+# Import the modules used
+from amocatlas import logger, utilities
+from amocatlas.logger import log_error, log_info, log_warning
+from amocatlas.utilities import apply_defaults
+from amocatlas.reader_utils import ReaderUtils
+
+log = logger.log  # Use the global logger
+
+# Datasource identifier for automatic standardization
+DATASOURCE_ID = "axmoc34s"
+
+# Default list of AXMOC34S data files
+AXMOC34S_DEFAULT_FILES = ["AXMOC_34S_timeseries_2005_2023.nc"]
+AXMOC34S_TRANSPORT_FILES = ["AXMOC_34S_timeseries_2005_2023.nc"]
+AXMOC34S_DEFAULT_SOURCE = "https://zenodo.org/records/18839461/files/"
+
+AXMOC34S_METADATA = {
+    "project": "AMOC transport at 34.5S from sustained in situ observations",
+    "weblink": "https://zenodo.org/records/18839461",
+    "comment": "Dataset accessed and processed via http://github.com/AMOCcommunity/amocatlas",
+}
+
+AXMOC34S_FILE_METADATA = {
+    "AXMOC_34S_timeseries_2005_2023.nc": {
+        "data_product": "AMOC and MHT transport data at 34.5°S",
+    },
+}
+
+
+@apply_defaults(AXMOC34S_DEFAULT_SOURCE, AXMOC34S_DEFAULT_FILES)
+def read_axmoc34s(
+    source: Union[str, Path, None],
+    file_list: Union[str, list[str]],
+    transport_only: bool = True,
+    data_dir: Union[str, Path, None] = None,
+    redownload: bool = False,
+    track_added_attrs: bool = False,
+) -> list[xr.Dataset]:
+    """Load the AXMOC34S datasets from a URL or local file path into xarray Datasets.
+
+    Parameters
+    ----------
+    source : str, optional
+        Local path to the data directory (remote source is handled per-file).
+
+    file_list : str or list of str, optional
+        Filename or list of filenames to process.
+        Defaults to AXMOC34S_DEFAULT_FILES.
+
+    transport_only : bool, optional
+        If True, restrict to transport files only.
+
+    data_dir : str, Path or None, optional
+        Optional local data directory.
+
+    redownload : bool, optional
+        If True, force redownload of the data.
+    track_added_attrs : bool, optional
+        If True, track which attributes were added during metadata enrichment.
+
+    Returns
+    -------
+    list of xr.Dataset
+        List of loaded xarray datasets with basic inline and file-specific metadata.
+
+    Raises
+    ------
+    ValueError
+        If no source is provided for a file and no default URL mapping is found.
+
+    FileNotFoundError
+        If the file cannot be downloaded or does not exist locally.
+
+    """
+    log.info("Starting to read AXMOC34S dataset")
+
+    # Load YAML metadata with fallback
+    global_metadata, yaml_file_metadata = ReaderUtils.load_array_metadata_with_fallback(
+        DATASOURCE_ID, AXMOC34S_METADATA
+    )
+
+    # Ensure file_list has a default
+    if file_list is None:
+        file_list = AXMOC34S_DEFAULT_FILES
+    if transport_only:
+        file_list = AXMOC34S_TRANSPORT_FILES
+    if isinstance(file_list, str):
+        file_list = [file_list]
+    # Determine the local storage path
+    local_data_dir = Path(data_dir) if data_dir else utilities.get_default_data_dir()
+    local_data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Print information about files being loaded
+    ReaderUtils.print_loading_info(file_list, DATASOURCE_ID, AXMOC34S_FILE_METADATA)
+
+    datasets = []
+
+    added_attrs_per_dataset = [] if track_added_attrs else None
+    for file in file_list:
+        if not (file.lower().endswith(".nc")):
+            log_warning("Skipping unsupported file type : %s", file)
+            continue
+
+        download_url = (
+            f"{source.rstrip('/')}/{file}" if utilities.is_valid_url(source) else None
+        )
+
+        file_path = utilities.resolve_file_path(
+            file_name=file,
+            source=source,
+            download_url=download_url,
+            local_data_dir=local_data_dir,
+            redownload=redownload,
+        )
+
+        # Open dataset
+
+        if file.lower().endswith(".nc"):
+            # Use ReaderUtils for consistent dataset loading
+
+            ds = ReaderUtils.safe_load_dataset(file_path)
+            # Attach metadata
+            # Attach metadata with optional tracking
+
+            if track_added_attrs:
+                ds, attr_changes = ReaderUtils.attach_metadata_with_tracking(
+                    ds,
+                    file,
+                    file_path,
+                    global_metadata,
+                    yaml_file_metadata,
+                    AXMOC34S_FILE_METADATA,
+                    DATASOURCE_ID,
+                    track_added_attrs=True,
+                )
+
+                added_attrs_per_dataset.append(attr_changes)
+
+            else:
+                ds = ReaderUtils.attach_metadata_with_tracking(
+                    ds,
+                    file,
+                    file_path,
+                    global_metadata,
+                    yaml_file_metadata,
+                    AXMOC34S_FILE_METADATA,
+                    DATASOURCE_ID,
+                    track_added_attrs=False,
+                )
+        else:
+            raise ValueError(
+                f"Unsupported file type for {file}. Only .nc files are supported."
+            )
+
+        datasets.append(ds)
+
+    if not datasets:
+        log_error("No valid AXMOC34S files in %s", file_list)
+        raise FileNotFoundError(f"No valid data files found in {file_list}")
+
+    log_info("Successfully loaded %d AXMOC34S dataset(s)", len(datasets))
+
+    if track_added_attrs:
+        return datasets, added_attrs_per_dataset
+    else:
+        return datasets

--- a/amocatlas/data_sources/axmoc34s.py
+++ b/amocatlas/data_sources/axmoc34s.py
@@ -1,14 +1,14 @@
 """AMOC at 34.5°S transport data reader for AMOCatlas.
 
-This module provides functions to read and process AMOC and meridional heat and freshwater transport data at 34.5°S based on sustained in situ observations.
+This module provides functions to read and process AMOC, meridional heat and freshwater transport data at 34.5°S based on sustained in situ observations.
 
-Dataset includes estimates of AMOC, heat and freshwatertransport at 34.5°S. All three also have the Ekman and geostrophic component available.
+Dataset includes estimates of AMOC, heat and freshwater transport at 34.5°S. All three also have the Ekman and geostrophic component available.
 
 Key functions:
-- read_axmoc34s(): Main data loading interface for AMOC transport data at 34.5°S which includes both datasets
+- read_axmoc34s(): Main data loading interface for AMOC, meridional heat and freshwater transport data at 34.5°S
 
 Data source: AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations
-Location: North Atlantic at 34.5°S
+Location: South Atlantic at 34.5°S
 """
 
 from pathlib import Path
@@ -40,7 +40,7 @@ AXMOC34S_METADATA = {
 
 AXMOC34S_FILE_METADATA = {
     "AXMOC_34S_timeseries_2005_2023.nc": {
-        "data_product": "AMOC and MHT transport data at 34.5°S",
+        "data_product": "AMOC, MHT and FOV transport data at 34.5°S",
     },
 }
 

--- a/amocatlas/defaults.py
+++ b/amocatlas/defaults.py
@@ -241,6 +241,8 @@ ARRAY_NAMES = [
     "nac",  # North Atlantic Current
     "sf2021",  # Sanchez-Franks 2021 satellite reconstruction of AMOC transport at 26°N
     "lebras35n",  # Lebras 2023 AMOC transport at 35°N
+    "axmoc22s",  # AXMOC and heat transport from sustained in situ observations at 22.5°S
+    "axmoc34s",  # AXMOC, heat and freshwater transport from sustained in situ observations 34.5°S
 ]
 
 # Mapping from array names to their full descriptions
@@ -261,6 +263,8 @@ ARRAY_DESCRIPTIONS = {
     "nac": "North Atlantic Current - Transport estimate from satellite altimetry and float observations",
     "sf2021": "SF2021 - Sanchez-Franks 2021 satellite reconstruction of AMOC transport at 26°N",
     "lebras35n": "Le Bras 2023 - AMOC transport estimates at 35°N from satellite altimetry and in situ data",
+    "axmoc22s": "AXMOC 22.5°S - AMOC and heat transport from sustained in situ observations at 22.5°S",
+    "axmoc34s": "AXMOC 34.5°S - AMOC, heat and freshwater transport from sustained in situ observations at 34.5°S",
 }
 
 # Preferred units

--- a/amocatlas/metadata/axmoc22s.yml
+++ b/amocatlas/metadata/axmoc22s.yml
@@ -1,0 +1,59 @@
+metadata:
+  program: "AXMOC22S"
+  description: "Estimates of AMOC and heat transport at 22.5°S"
+  project: "I. Pita, M. Goes - AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations"
+  weblink: https://zenodo.org/records/18839461
+  comment: Dataset accessed and processed via http://github.com/AMOCcommunity/amocatlas
+  acknowledgments: >
+    This research was carried out in part under the auspices of the Cooperative Institute for Marine and Atmospheric Studies, a cooperative institute of the University of Miami and the National Oceanic and Atmospheric Administration (NOAA), cooperative agreement NA20OAR4320472, and was supported by NOAA's Atlantic Oceanographic and Meteorological Laboratory (AOML). MG and DLV were also supported by the National Oceanic and Atmospheric Administration (NOAA) Climate Variability and Predictability program (Grant NA20OAR4310407).
+  citation: >
+    Pita, I., Goes, M., Volkov, D. L., Dong, S., Goni, G., & Cirano, M. (2024). An ARGO and XBT observing system for the Atlantic Meridional Overturning Circulation and Meridional Heat Transport (AXMOC) at 22.5°S. Journal of Geophysical Research: Oceans, 129, e2023JC020010. https://doi.org/10.1029/2023JC020010
+  license: 
+  featureType: timeSeries
+  time_coverage_start: '2007-11-13'
+  time_coverage_end: '2023-05-18'
+  contributing_institutions: "University of Miami, NOAA"
+
+files:
+  AXMOC_22S_timeseries_2007_2023.nc:
+    source_url: https://zenodo.org/records/18839461/files/
+    data_product: "Estimates of AMOC, heat and freshwater transports at 22.5°S based on sustained in situ observations"
+    variable_mapping:
+      "time": TIME
+      "moc_total": MOC
+      "moc_ekman": TRANS_EKMAN
+      "moc_geostrophic": TRANS_GEOSTROPHIC
+      "mht_total": MHT
+      "mht_ekman": MHT_EKMAN
+      "mht_geostrophic": MHT_GEOSTROPHIC
+    original_variable_metadata:
+      moc_total:
+        long_name: "Total AMOC"
+        description: "Total AMOC transport time series at 22.5°S"
+        units: Sverdrup
+        standard_name: ocean_meridional_overturning_streamfunction
+      moc_ekman:
+        long_name: "Ekman AMOC"
+        description: "Ekman component of AMOC transport time series at 22.5°S"
+        units: Sverdrup
+        standard_name: ocean_volume_transport_across_line
+      moc_geostrophic:
+        long_name: "Geostrophic AMOC"
+        description: "Geostrophic component of AMOC transport time series at 22.5°S"
+        units: Sverdrup
+        standard_name: ocean_volume_transport_across_line
+      mht_total:
+        long_name: "Total MHT"
+        description: "Total meridional heat transport at 22.5°S"
+        units: PW
+        standard_name: northward_ocean_heat_transport
+      mht_ekman:
+        long_name: "Ekman MHT"
+        description: "Ekman component of meridional heat transport at 22.5°S"
+        units: PW
+        standard_name: northward_ocean_heat_transport_component
+      mht_geostrophic:
+        long_name: "Geostrophic MHT"
+        description: "Geostrophic component of meridional heat transport at 22.5°S"
+        units: PW
+        standard_name: northward_ocean_heat_transport_component

--- a/amocatlas/metadata/axmoc22s.yml
+++ b/amocatlas/metadata/axmoc22s.yml
@@ -17,7 +17,7 @@ metadata:
 files:
   AXMOC_22S_timeseries_2007_2023.nc:
     source_url: https://zenodo.org/records/18839461/files/
-    data_product: "Estimates of AMOC, heat and freshwater transports at 22.5°S based on sustained in situ observations"
+    data_product: "Estimates of AMOC and meridional heat transports at 22.5°S based on sustained in situ observations"
     variable_mapping:
       "time": TIME
       "moc_total": MOC

--- a/amocatlas/metadata/axmoc34s.yml
+++ b/amocatlas/metadata/axmoc34s.yml
@@ -1,0 +1,77 @@
+metadata:
+  program: "AXMOC34S"
+  description: "Estimates of AMOC and heat transport at 34.5°S"
+  project: "I. Pita, M. Goes - AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations"
+  weblink: https://zenodo.org/records/18839461
+  comment: Dataset accessed and processed via http://github.com/AMOCcommunity/amocatlas
+  acknowledgments: >
+    The author(s) declare that financial support was received for the research, authorship, and/or publication of this article. This research was carried out in part under the auspices of the Cooperative Institute for Marine and Atmospheric Studies, a cooperative institute of the University of Miami and the National Oceanic and Atmospheric Administration (NOAA), cooperative agreement NA20OAR4320472, and was supported by NOAA's Atlantic Oceanographic and Meteorological Laboratory (AOML). MG and DLV were also supported by the National Oceanic and Atmospheric Administration (NOAA) Climate Variability and Predictability program (Grant NA20OAR4310407)
+  citation: >
+    Pita I, Goes M, Volkov DL, Dong S and Schmid C (2024) South Atlantic meridional overturning circulation and its respective heat and freshwater transports from sustained observations near 34.5°S. Front. Mar. Sci. 11:1474133. doi: 10.3389/fmars.2024.1474133
+  license: 
+  featureType: timeSeries
+  time_coverage_start: '2005-11-13'
+  time_coverage_end: '2023-05-18'
+  contributing_institutions: "University of Miami, NOAA"
+
+files:
+  AXMOC_34S_timeseries_2005_2023.nc:
+    source_url: https://zenodo.org/records/18839461/files/
+    data_product: "Estimates of AMOC, heat and freshwater transports at 34.5°S based on sustained in situ observations"
+    variable_mapping:
+      "time": TIME
+      "moc_total": MOC
+      "moc_ekman": TRANS_EKMAN
+      "moc_geostrophic": TRANS_GEOSTROPHIC
+      "mht_total": MHT
+      "mht_ekman": MHT_EKMAN
+      "mht_geostrophic": MHT_GEOSTROPHIC
+      "fov_total": FOV
+      "fov_ekman": FOV_EKMAN
+      "fov_geostrophic": FOV_GEOSTROPHIC
+    original_variable_metadata:
+      moc_total:
+        long_name: "Total AMOC"
+        description: "Total AMOC transport time series at 34.5°S"
+        units: Sverdrup
+        standard_name: ocean_meridional_overturning_streamfunction
+      moc_ekman:
+        long_name: "Ekman AMOC"
+        description: "Ekman component of AMOC transport time series at 34.5°S"
+        units: Sverdrup
+        standard_name: ocean_volume_transport_across_line
+      moc_geostrophic:
+        long_name: "Geostrophic AMOC"
+        description: "Geostrophic component of AMOC transport time series at 34.5°S"
+        units: Sverdrup
+        standard_name: ocean_volume_transport_across_line
+      mht_total:
+        long_name: "Total MHT"
+        description: "Total meridional heat transport at 34.5°S"
+        units: PW
+        standard_name: northward_ocean_heat_transport
+      mht_ekman:
+        long_name: "Ekman MHT"
+        description: "Ekman component of meridional heat transport at 34.5°S"
+        units: PW
+        standard_name: northward_ocean_heat_transport_component
+      mht_geostrophic:
+        long_name: "Geostrophic MHT"
+        description: "Geostrophic component of meridional heat transport at 34.5°S"
+        units: PW
+        standard_name: northward_ocean_heat_transport_component
+      fov_total:
+        long_name: "Total FOV"
+        description: "Overturning component of freshwater transport at 34.5°S, also referred to as Fov or Mov"
+        units: Sv
+        standard_name: northward_ocean_freshwater_transport
+      fov_ekman:
+        long_name: "Ekman FOV"
+        description: "Ekman contribution to overturning freshwater transport at 34.5°S"
+        units: Sv
+        standard_name: northward_ocean_freshwater_transport_component
+      fov_geostrophic:
+        long_name: "Geostrophic FOV"
+        description: "Geostrophic contribution to overturning freshwater transport at 34.5°S"
+        units: Sv
+        standard_name: northward_ocean_freshwater_transport_component

--- a/amocatlas/metadata/axmoc34s.yml
+++ b/amocatlas/metadata/axmoc34s.yml
@@ -1,6 +1,6 @@
 metadata:
   program: "AXMOC34S"
-  description: "Estimates of AMOC and heat transport at 34.5°S"
+  description: "Estimates of AMOC, heat and freshwater transports at 34.5°S"
   project: "I. Pita, M. Goes - AXMOC: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations"
   weblink: https://zenodo.org/records/18839461
   comment: Dataset accessed and processed via http://github.com/AMOCcommunity/amocatlas
@@ -63,15 +63,15 @@ files:
       fov_total:
         long_name: "Total FOV"
         description: "Overturning component of freshwater transport at 34.5°S, also referred to as Fov or Mov"
-        units: Sv
+        units: Sverdrup
         standard_name: northward_ocean_freshwater_transport
       fov_ekman:
         long_name: "Ekman FOV"
         description: "Ekman contribution to overturning freshwater transport at 34.5°S"
-        units: Sv
+        units: Sverdrup
         standard_name: northward_ocean_freshwater_transport_component
       fov_geostrophic:
         long_name: "Geostrophic FOV"
         description: "Geostrophic contribution to overturning freshwater transport at 34.5°S"
-        units: Sv
+        units: Sverdrup
         standard_name: northward_ocean_freshwater_transport_component

--- a/amocatlas/read.py
+++ b/amocatlas/read.py
@@ -53,6 +53,8 @@ from .data_sources import (
     read_nac,
     read_sf2021,
     read_lebras35n,
+    read_axmoc22s,
+    read_axmoc34s,
 )
 
 # Import file constants for list_files() functionality
@@ -72,6 +74,8 @@ from .data_sources.arcticgateway import ARCTIC_DEFAULT_FILES
 from .data_sources.nac import NAC_DEFAULT_FILES
 from .data_sources.sf2021 import SF2021_DEFAULT_FILES
 from .data_sources.lebras35n import LEBRAS35N_DEFAULT_FILES
+from .data_sources.axmoc22s import AXMOC22S_DEFAULT_FILES
+from .data_sources.axmoc34s import AXMOC34S_DEFAULT_FILES
 
 # Import standardization functions
 from . import standardise
@@ -94,6 +98,8 @@ SUPPORTED_STANDARDIZATION = {
     "nac",
     "sf2021",
     "lebras35n",
+    "axmoc22s",
+    "axmoc34s",
 }
 
 
@@ -364,7 +370,7 @@ def _create_array_function(
     redownload : bool, optional
         Force redownload of data. Default: False.
     version : str, optional
-        Dataset version{' (used for version selection)' if supports_version else ' (ignored for this array)'}. Default: None.
+        Dataset version{" (used for version selection)" if supports_version else " (ignored for this array)"}. Default: None.
     track_added_attrs : bool, optional
         **INTERNAL USE ONLY** - Track which attributes were added during metadata
         enrichment. When True, embeds a temporary '_amocatlas_metadata_changes'
@@ -448,6 +454,17 @@ lebras35n = _create_array_function(
     "Le Bras et al. 2023 at 35°N",
     available_files=LEBRAS35N_DEFAULT_FILES,
 )
+axmoc22s = _create_array_function(
+    read_axmoc22s,
+    "AXMOC 22.5°S",
+    available_files=AXMOC22S_DEFAULT_FILES,
+)
+axmoc34s = _create_array_function(
+    read_axmoc34s,
+    "AXMOC 34.5°S",
+    available_files=AXMOC34S_DEFAULT_FILES,
+)
+
 # Define __all__ to control what's exported
 __all__ = [
     "rapid",
@@ -466,4 +483,6 @@ __all__ = [
     "nac",
     "sf2021",
     "lebras35n",
+    "axmoc22s",
+    "axmoc34s",
 ]

--- a/amocatlas/reader_utils.py
+++ b/amocatlas/reader_utils.py
@@ -39,6 +39,8 @@ DATASOURCE_DISPLAY_NAMES = {
     "nac": "North Atlantic Current, M. Lankhorst, 2025",
     "sf2021": "Sanchez-Franks et al. 2021",
     "lebras35n": "Le Bras et al. 2023 at 35°N",
+    "axmoc22s": "AXMOC 22.5°S",
+    "axmoc34s": "AXMOC 34.5°S",
 }
 
 

--- a/amocatlas/readers.py
+++ b/amocatlas/readers.py
@@ -44,6 +44,8 @@ from amocatlas.data_sources import (
     read_nac,
     read_sf2021,
     read_lebras35n,
+    read_axmoc22s,
+    read_axmoc34s,
 )
 
 log = logger.log
@@ -89,6 +91,8 @@ def _get_reader(array_name: str) -> Callable[..., List[xr.Dataset]]:
         "nac": read_nac,
         "sf2021": read_sf2021,
         "lebras35n": read_lebras35n,
+        "axmoc22s": read_axmoc22s,
+        "axmoc34s": read_axmoc34s,
     }
     try:
         return readers[array_name.lower()]

--- a/amocatlas/standardise.py
+++ b/amocatlas/standardise.py
@@ -1204,6 +1204,30 @@ def standardise_lebras35n(ds: xr.Dataset, file_name: str) -> xr.Dataset:
     return standardise_array(ds, file_name)
 
 
+def standardise_axmoc22s(ds: xr.Dataset, file_name: str) -> xr.Dataset:
+    """Standardise AXMOC22S array dataset to consistent format."""
+    warnings.warn(
+        "standardise_axmoc22s() is deprecated and will be removed in a future version. "
+        "Use standardise_data() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return standardise_array(ds, file_name)
+
+
+def standardise_axmoc34s(ds: xr.Dataset, file_name: str) -> xr.Dataset:
+    """Standardise AXMOC34S array dataset to consistent format."""
+    warnings.warn(
+        "standardise_axmoc34s() is deprecated and will be removed in a future version. "
+        "Use standardise_data() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return standardise_array(ds, file_name)
+
+
 def standardise_data(ds: xr.Dataset, file_name: str) -> xr.Dataset:
     """Standardise a dataset using YAML-based metadata.
 

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -651,6 +651,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6d6087bb",
+   "metadata": {},
+   "source": [
+    "### Load the AXMOC transport data for 22.5°S and 34.5°S\n",
+    "- use read.axmoc22s() for the 22.5°S data (here we have MOC and MHT available)\n",
+    "- use read.axmoc34s() for the 34.5°S data (here we have MOC, MHT and FOV available) (FOV = opverturning component of freshwater transport)\n",
+    "\n",
+    "For both datasets we have the total, then the Ekman and the geostrophic component available "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0c7c808",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "standardAXMOC22S = read.axmoc22s()\n",
+    "standardAXMOC34S = read.axmoc34s()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e2df667",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotters.plot_amoc_timeseries(\n",
+    "    data=[standardAXMOC22S,standardAXMOC34S],\n",
+    "    varnames=[\"MOC\", \"MOC\"],\n",
+    "    labels=[\"MOC 22.5°S\", \"MOC 34.5°S\"],\n",
+    "    resample_monthly=False,\n",
+    "    plot_raw=True,\n",
+    "    colors=[\"red\", \"darkblue\"],\n",
+    "    title=\"AXMOC - MOC transport at 22.5°S and 34.5°S\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f1124d71",
    "metadata": {},
    "source": [

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -656,9 +656,9 @@
    "source": [
     "### Load the AXMOC transport data for 22.5°S and 34.5°S\n",
     "- use read.axmoc22s() for the 22.5°S data (here we have MOC and MHT available)\n",
-    "- use read.axmoc34s() for the 34.5°S data (here we have MOC, MHT and FOV available) (FOV = opverturning component of freshwater transport)\n",
+    "- use read.axmoc34s() for the 34.5°S data (here we have MOC, MHT and FOV available) (FOV = overturning component of freshwater transport)\n",
     "\n",
-    "For both datasets we have the total, then the Ekman and the geostrophic component available "
+    "For both datasets we have the total, then the Ekman and the geostrophic component available"
    ]
   },
   {

--- a/tests/test_axmoc22s.py
+++ b/tests/test_axmoc22s.py
@@ -1,0 +1,96 @@
+"""Tests for AXMOC 22.5°S data reader.
+
+Simple, targeted tests focusing on module structure and constants.
+Tests the basic functionality without complex data loading mocks.
+"""
+
+from amocatlas.data_sources import axmoc22s
+from amocatlas.logger import disable_logging
+
+# Keep tests quiet
+disable_logging()
+
+
+class TestAXMOC22S:
+    """Test basic AXMOC 22.5°S module functionality."""
+
+    def test_module_constants_defined(self):
+        """Test that all required module constants exist."""
+        assert hasattr(axmoc22s, "DATASOURCE_ID")
+        assert hasattr(axmoc22s, "AXMOC22S_DEFAULT_FILES")
+        assert hasattr(axmoc22s, "AXMOC22S_TRANSPORT_FILES")
+        assert hasattr(axmoc22s, "AXMOC22S_DEFAULT_SOURCE")
+        assert hasattr(axmoc22s, "AXMOC22S_METADATA")
+        assert hasattr(axmoc22s, "AXMOC22S_FILE_METADATA")
+
+        # Check values are sensible
+        assert axmoc22s.DATASOURCE_ID == "axmoc22s"
+        assert isinstance(axmoc22s.AXMOC22S_DEFAULT_FILES, list)
+        assert isinstance(axmoc22s.AXMOC22S_TRANSPORT_FILES, list)
+        assert isinstance(axmoc22s.AXMOC22S_DEFAULT_SOURCE, str)
+        assert axmoc22s.AXMOC22S_DEFAULT_SOURCE.startswith("https://")
+        assert isinstance(axmoc22s.AXMOC22S_METADATA, dict)
+        assert isinstance(axmoc22s.AXMOC22S_FILE_METADATA, dict)
+
+    def test_default_files_configuration(self):
+        """Test default files configuration is reasonable."""
+        files = axmoc22s.AXMOC22S_DEFAULT_FILES
+        assert len(files) > 0
+        assert "AXMOC_22S_timeseries_2007_2023.nc" in files
+
+        transport_files = axmoc22s.AXMOC22S_TRANSPORT_FILES
+        assert len(transport_files) > 0
+        assert "AXMOC_22S_timeseries_2007_2023.nc" in transport_files
+
+        # Files should be NetCDF format
+        for file in files:
+            assert file.endswith(".nc")
+
+    def test_metadata_structure(self):
+        """Test metadata structure is reasonable."""
+        metadata = axmoc22s.AXMOC22S_METADATA
+        assert isinstance(metadata, dict)
+
+        # Check for expected keys
+        expected_keys = ["project", "weblink", "comment"]
+        for key in expected_keys:
+            assert key in metadata, f"Expected metadata key '{key}' not found"
+
+        # Check values are non-empty strings
+        for _key, value in metadata.items():
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+    def test_file_metadata_structure(self):
+        """Test file metadata structure is reasonable."""
+        file_metadata = axmoc22s.AXMOC22S_FILE_METADATA
+        assert isinstance(file_metadata, dict)
+        assert "AXMOC_22S_timeseries_2007_2023.nc" in file_metadata
+
+        for _filename, metadata in file_metadata.items():
+            assert isinstance(metadata, dict)
+            assert "data_product" in metadata
+            assert isinstance(metadata["data_product"], str)
+            assert len(metadata["data_product"]) > 0
+
+    def test_function_exists_and_callable(self):
+        """Test that main function exists and is callable."""
+        assert hasattr(axmoc22s, "read_axmoc22s")
+        assert callable(axmoc22s.read_axmoc22s)
+
+        # Check function has documentation
+        func = axmoc22s.read_axmoc22s
+        assert func.__doc__ is not None
+        assert "AXMOC22S" in func.__doc__ or "transport" in func.__doc__
+
+    def test_module_docstring_informative(self):
+        """Test that module has informative docstring."""
+        assert axmoc22s.__doc__ is not None
+        assert "22.5" in axmoc22s.__doc__
+        assert "AMOC" in axmoc22s.__doc__
+        assert "transport" in axmoc22s.__doc__
+
+    def test_module_imports_successfully(self):
+        """Test that the module imports without errors."""
+        # This test passes if the module loaded successfully
+        assert axmoc22s is not None

--- a/tests/test_axmoc34s.py
+++ b/tests/test_axmoc34s.py
@@ -1,0 +1,96 @@
+"""Tests for AXMOC 34.5°S data reader.
+
+Simple, targeted tests focusing on module structure and constants.
+Tests the basic functionality without complex data loading mocks.
+"""
+
+from amocatlas.data_sources import axmoc34s
+from amocatlas.logger import disable_logging
+
+# Keep tests quiet
+disable_logging()
+
+
+class TestAXMOC34S:
+    """Test basic AXMOC 34.5°S module functionality."""
+
+    def test_module_constants_defined(self):
+        """Test that all required module constants exist."""
+        assert hasattr(axmoc34s, "DATASOURCE_ID")
+        assert hasattr(axmoc34s, "AXMOC34S_DEFAULT_FILES")
+        assert hasattr(axmoc34s, "AXMOC34S_TRANSPORT_FILES")
+        assert hasattr(axmoc34s, "AXMOC34S_DEFAULT_SOURCE")
+        assert hasattr(axmoc34s, "AXMOC34S_METADATA")
+        assert hasattr(axmoc34s, "AXMOC34S_FILE_METADATA")
+
+        # Check values are sensible
+        assert axmoc34s.DATASOURCE_ID == "axmoc34s"
+        assert isinstance(axmoc34s.AXMOC34S_DEFAULT_FILES, list)
+        assert isinstance(axmoc34s.AXMOC34S_TRANSPORT_FILES, list)
+        assert isinstance(axmoc34s.AXMOC34S_DEFAULT_SOURCE, str)
+        assert axmoc34s.AXMOC34S_DEFAULT_SOURCE.startswith("https://")
+        assert isinstance(axmoc34s.AXMOC34S_METADATA, dict)
+        assert isinstance(axmoc34s.AXMOC34S_FILE_METADATA, dict)
+
+    def test_default_files_configuration(self):
+        """Test default files configuration is reasonable."""
+        files = axmoc34s.AXMOC34S_DEFAULT_FILES
+        assert len(files) > 0
+        assert "AXMOC_34S_timeseries_2005_2023.nc" in files
+
+        transport_files = axmoc34s.AXMOC34S_TRANSPORT_FILES
+        assert len(transport_files) > 0
+        assert "AXMOC_34S_timeseries_2005_2023.nc" in transport_files
+
+        # Files should be NetCDF format
+        for file in files:
+            assert file.endswith(".nc")
+
+    def test_metadata_structure(self):
+        """Test metadata structure is reasonable."""
+        metadata = axmoc34s.AXMOC34S_METADATA
+        assert isinstance(metadata, dict)
+
+        # Check for expected keys
+        expected_keys = ["project", "weblink", "comment"]
+        for key in expected_keys:
+            assert key in metadata, f"Expected metadata key '{key}' not found"
+
+        # Check values are non-empty strings
+        for _key, value in metadata.items():
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+    def test_file_metadata_structure(self):
+        """Test file metadata structure is reasonable."""
+        file_metadata = axmoc34s.AXMOC34S_FILE_METADATA
+        assert isinstance(file_metadata, dict)
+        assert "AXMOC_34S_timeseries_2005_2023.nc" in file_metadata
+
+        for _filename, metadata in file_metadata.items():
+            assert isinstance(metadata, dict)
+            assert "data_product" in metadata
+            assert isinstance(metadata["data_product"], str)
+            assert len(metadata["data_product"]) > 0
+
+    def test_function_exists_and_callable(self):
+        """Test that main function exists and is callable."""
+        assert hasattr(axmoc34s, "read_axmoc34s")
+        assert callable(axmoc34s.read_axmoc34s)
+
+        # Check function has documentation
+        func = axmoc34s.read_axmoc34s
+        assert func.__doc__ is not None
+        assert "AXMOC22S" in func.__doc__ or "transport" in func.__doc__
+
+    def test_module_docstring_informative(self):
+        """Test that module has informative docstring."""
+        assert axmoc34s.__doc__ is not None
+        assert "34.5" in axmoc34s.__doc__
+        assert "AMOC" in axmoc34s.__doc__
+        assert "transport" in axmoc34s.__doc__
+
+    def test_module_imports_successfully(self):
+        """Test that the module imports without errors."""
+        # This test passes if the module loaded successfully
+        assert axmoc34s is not None


### PR DESCRIPTION
**Description:**
New reader for AXMOC dataset: Estimate of AMOC, heat and freshwater transports at 22.5 and 34.5S based on sustained in situ observations.

Two individual readers were implemented here, which are based on the same methodology and provided through the same website: https://zenodo.org/records/18839461 

_1. Reader:_
AMOC and heat transport timeseries for 22.5°S

New files: 
- `axmoc22s.py` (for reading the dataset)
- `axmoc22s.yml` (to assign metadata and map variables)
- `test_axmoc22s.py` (perform basic functionality tests) 

_2. Reader_
AMOC, heat and freshwater transport for 34.5°S

New files: 
- `axmoc34s.py` (for reading the dataset)
- `axmoc34s.yml` (to assign metadata and map variables)
- `test_axmoc34s.py` (perform basic functionality tests) 

Files that were adjusted for both readers:
- `__init__.py` (to initialize)
- `defaults.py` (set default title/ description for the readers)
- `reader_utils.py` (set display names)
- `readers.py` (define readers for the reader function)
- `read.py` (define readers for the reader function)
- `standardise.py` (add readers to standardization process)
- `demo.ipynb` (visualize both dataset's MOC component)

**Related Issues / Pull Requests:**

- Fixes #138 
- Related to #138 