### PR TITLE
[CI] remove pip bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,5 @@
 version: 2
 updates:
-  # Python dependencies
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      time: "09:00"
-      timezone: "UTC"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "[DEPS]"
-      include: "scope"
-    reviewers:
-      - "eleanorfrajka"
-      - "isaschmitz"
-    assignees:
-      - "eleanorfrajka"
-      - "isaschmitz"
-    labels:
-      - "dependencies"
-      - "automated"
-    groups:
-      minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Removed the dependabot bumps for pip installed packages; keeping bumps for GitHub actions only.