### PR TITLE
[CHORE] Docs deploy: copy notebooks offline; force_orphan gh-pages to…

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -40,10 +40,11 @@ jobs:
         shell: bash -l {0}
         run: |
           set -e
-          micromamba run -n amocatlas jupyter nbconvert --to notebook --execute notebooks/demo.ipynb --output=demo-output.ipynb --ExecutePreprocessor.allow_errors=False
-          # Copy the paperfigs notebook without executing (requires PyGMT/GMT which aren't available in CI)
+          # Copy notebooks without executing. They read live data from remote array
+          # servers, which is unavailable/flaky in CI. Execute locally and commit the
+          # outputs to render them (nbsphinx_execute is "never"; see docs/source/conf.py).
+          cp notebooks/demo.ipynb docs/source/demo-output.ipynb
           cp notebooks/amoc_paperfigs.ipynb docs/source/amoc_paperfigs-output.ipynb
-          mv notebooks/*output.ipynb docs/source/
           pushd docs
           micromamba run -n amocatlas make clean html
           popd
@@ -53,3 +54,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html
+          # Replace gh-pages with a single commit each deploy: the built site is
+          # regenerable, and keeping full history re-committed the whole site every
+          # run (107 copies of the built demo notebook bloated gh-pages to ~71 MB).
+          force_orphan: true


### PR DESCRIPTION
## Summary

Two fixes to the GitHub Pages deploy workflow (`.github/workflows/docs_deploy.yml`): stop re-committing the full built site to `gh-pages` on every run, and stop executing notebooks (which download data) at deploy time.

## force_orphan the gh-pages deploy

The deploy used `peaceiris/actions-gh-pages` without `force_orphan`, so every run appended a new commit containing the entire built site. Over time this accumulated a large `gh-pages` history (dozens of copies of the built notebooks and figures), which every full clone downloads. Setting `force_orphan: true` makes each deploy replace `gh-pages` with a single commit: the next deploy squashes the existing history, and it can no longer grow. The published site is regenerable, so no history is lost.

## Copy notebooks instead of executing them

The deploy build step ran `jupyter nbconvert --execute notebooks/demo.ipynb`, which reads live data from remote array servers — unavailable or flaky in CI, and unnecessary for the rendered docs. The PR-check workflow (`docs.yml`) and `docs/source/conf.py` (`nbsphinx_execute = "never"`) already switched to copying the notebooks without executing; this brings the deploy workflow in line. The demo notebook renders from its committed (empty) cells; execute it locally and commit outputs if rendered output is wanted.

## Effect

- `gh-pages` collapses to a single commit on the next deploy and stays that way.
- The deploy no longer downloads data or depends on remote servers, so it is deterministic and offline.
- No change to the published documentation content.
