### PR TITLE
[FIX] TIME converter honours declared epoch; strip internal dict attrs; harden downloads with atomic writes + provenance sidecars

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -54,7 +54,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html
-          # Replace gh-pages with a single commit each deploy: the built site is
-          # regenerable, and keeping full history re-committed the whole site every
-          # run (107 copies of the built demo notebook bloated gh-pages to ~71 MB).
+          # Replace gh-pages with a single commit each deploy. The built site is
+          # regenerable, so its history has no value. The saving is smaller than it
+          # looks: git deltas near-identical HTML well, and squashing 70-120 deploys
+          # shrinks a fresh clone by only 4-18%. What it does bound is the growth from
+          # re-executed demo notebooks, whose embedded PNGs differ every build and so
+          # never delta. Current site size dominates, not history - keep _static small.
           force_orphan: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 - [I Have a Question](#i-have-a-question)
 - [I Want To Contribute](#i-want-to-contribute)
+- [Licensing of Contributions](#licensing-of-contributions)
+- [Credit and Authorship](#credit-and-authorship)
 - [Reporting Bugs](#reporting-bugs)
 - [Suggesting Enhancements](#suggesting-enhancements)
 - [Your First Code Contribution](#your-first-code-contribution)
@@ -51,8 +53,30 @@ Depending on how large the project is, you may want to outsource the questioning
 
 ## I Want To Contribute
 
-> ### Legal Notice <!-- omit in toc -->
-> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project licence.
+Please read the two short sections on licensing and credit before opening a pull request. They exist so that nobody has to have an awkward retrospective conversation about attribution — which, for a package whose whole product is correct attribution, matters more here than in most projects.
+
+### Licensing of Contributions
+
+amocatlas is MIT licensed (see `LICENSE`), and contributions are accepted **under the same licence** — what GitHub calls "inbound = outbound". By opening a pull request you confirm that:
+
+1. you wrote the contribution, or you otherwise have the right to submit it; and
+2. you agree to license it to the project under the MIT licence.
+
+This does not transfer your copyright, which remains yours.
+
+**If your contribution contains code or data from somewhere else** — another repository, a paper's supplementary material, a Stack Overflow answer, a colleague's script, or generated output you did not review line by line — say so in the pull request and name the source and its licence. This is the single most useful thing you can tell a reviewer. Code from an unlicensed or incompatibly-licensed source cannot be merged until that is resolved, so flagging it early avoids wasted work.
+
+### Credit and Authorship
+
+Three separate things, often confused:
+
+**Copyright** stays with whoever wrote the code. You are not asked to assign it.
+
+**Contributor credit** is automatic. Everyone whose pull request is merged appears in the git history. If your name or preferred email in the git log is wrong, open an issue or a PR to correct it.
+
+**Citation authorship** is the author list in `CITATION.cff`, which propagates into the Zenodo/GitHub citation record for every release and therefore into other people's bibliographies. It reflects *substantial* contribution to the software — its design, a significant body of its implementation, its test suite, or its documentation architecture — and is decided by the maintainers at release time. Funding or supervision alone does not qualify. There is no line count that guarantees it and none that excludes it: a well-designed module that fixes a whole class of problem may count where a large mechanical change does not. If you believe your contribution crosses that line and it has not been reflected, say so in an issue — being asked is better than being resented.
+
+Where a contribution is adapted from someone else's work rather than written from scratch, credit it **in the docstring of the code itself** (an "original author" line), so the attribution travels with the code rather than living only in a file nobody reads.
 
 ### Reporting Bugs
 
@@ -134,8 +158,18 @@ The *.py* files are separated into broad categories of readers (to load datesets
 - Did you write a docstring? We use the [numpy standard for docstings](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard). We also suggest including your name or GitHub handle under the original author heading. Look at some existing docstrings in `amocatlas` if you are unsure of the format.
 - There are also some basic error checking behaviours you should consider including. If you're plotting a particular variable, use the `amocatlas.utilities._check_necessary_variables()` function to check whether or not the required variables are within the dataset passed to the function.
 - For plotting functions on a single axis, you should include as optional inputs the `fig` and `ax`, and return the same, to enable their usage within multi-axes plots. For plotting functions with multiple or interrelated axes, perhaps fig and ax shouldn't be included as inputs, but can be provided as outputs for the user to make onward edits.
-- For plotting, see the guidance on uniformity (using standard lineswidths, figure sizes and font sizes etc.). These are all described in `amocatlas/amocatlas.mplstyle`, in case an individual user wants to change these to their preferences.
+- For plotting, keep figures visually consistent with the existing ones: reuse the line widths, figure sizes, and font sizes already used in `plotters.py` rather than introducing new magic values scattered through the code.
 - Each new function should have a corresponding test, feel free to ask if you're not sure how to write a test!
+
+### Metadata, provenance, and pull-request hygiene
+
+amocatlas creates no science data — its product is *metadata*: the same numbers as the upstream publications, re-served with correct attribution, vocabulary, units, and provenance. A few conventions follow directly from that:
+
+- **Never silently substitute a default** where the correct value cannot be determined. Leave it empty, or raise / warn loudly and record what was assumed. A plausible wrong value (a mangled contributor name, a dropped EDMO code, a wrong-hemisphere latitude) is worse than a missing one, because nothing downstream can detect it.
+- **Preserve upstream qualifiers and units exactly.** Units are not optional; never strip or assume them.
+- **Record provenance.** When a processing step applies a correction, threshold, or registry replacement, make it inspectable — prefer a `warnings.warn` a user will see in a notebook over a DEBUG log they never read, and where relevant record what was applied in the output's attributes.
+- **One logical change per pull request.** A rename PR that also fixes a bug, or a fix that also carries an unrelated feature, is a PR nobody can review cleanly. If two changes are independent, split them.
+- **Tests should assert a value, not that something ran.** For anything numerical, assert against a figure you can justify independently of the code. Avoid tests that pass when nothing happened — `assert result is not None` on a function that returns `None` on failure is the shape to avoid.
 
 ### Jupyter Notebook Guidelines
 
@@ -156,7 +190,7 @@ Our [documentation](https://amoccommunity.github.io/AMOCatlas/) is built from th
 To build the documentation locally you need to install a few extra requirements:
 
 - Install `make` for your computer, e.g. on ubuntu with `sudo apt install make`
-- Install the additional python requirements. Activate the environment you use for working with glidertest, navigate to the top directory of this repo, then run `pip install -r requirements-dev.txt`
+- Install the additional python requirements. Activate the environment you use for amocatlas, navigate to the top directory of this repo, then run `pip install -r requirements-dev.txt`
 
 Once you have the extras installed, you can build the docs locally by navigating to the `docs/` directory and running `make clean html`. This command will create a directory called `build/` which contains the html files of the documentation. Open the file `docs/build/html/index.html` in your browser, and you will see the docs with your changes applied. After making more changes, just run make clean html again to rebuild the docs.
 

--- a/amocatlas/standardise.py
+++ b/amocatlas/standardise.py
@@ -732,6 +732,43 @@ def merge_metadata_aliases(attrs: dict, preferred_keys: dict) -> dict:
     return merged
 
 
+_TIME_UNIT_ALIASES = {
+    "seconds": "s",
+    "second": "s",
+    "secs": "s",
+    "sec": "s",
+    "s": "s",
+    "minutes": "m",
+    "minute": "m",
+    "mins": "m",
+    "min": "m",
+    "hours": "h",
+    "hour": "h",
+    "hrs": "h",
+    "hr": "h",
+    "h": "h",
+    "days": "D",
+    "day": "D",
+    "d": "D",
+}
+
+
+def _parse_cf_time_units(units: str) -> "tuple[str, str] | None":
+    """Parse a CF time-units string into a (pandas unit, origin) pair.
+
+    For example ``"days since 1950-01-01"`` returns ``("D", "1950-01-01")``. Returns
+    ``None`` if the string is not a recognised ``"<interval> since <date>"`` form, so the
+    caller can fall back explicitly rather than silently assuming an epoch.
+    """
+    match = re.match(r"\s*(\w+)\s+since\s+(.+?)\s*$", units, re.IGNORECASE)
+    if not match:
+        return None
+    pandas_unit = _TIME_UNIT_ALIASES.get(match.group(1).lower())
+    if pandas_unit is None:
+        return None
+    return pandas_unit, match.group(2).strip()
+
+
 def standardize_time_coordinate(ds: xr.Dataset) -> xr.Dataset:
     """Standardize TIME coordinate to comply with AMOCatlas specifications.
 
@@ -785,16 +822,24 @@ def standardize_time_coordinate(ds: xr.Dataset) -> xr.Dataset:
                 units = time_coord.attrs.get(
                     "units", "seconds since 1970-01-01T00:00:00Z"
                 )
-                if "since" in units.lower():
-                    # Parse the units and convert
+                parsed_units = _parse_cf_time_units(units)
+                if parsed_units is not None:
+                    # Honour the declared interval and epoch, e.g. "days since 1950-01-01".
+                    pandas_unit, origin = parsed_units
                     time_datetime = pd.to_datetime(
                         time_coord.values,
-                        unit="s",
-                        origin="1970-01-01",
+                        unit=pandas_unit,
+                        origin=origin,
                         errors="coerce",
                     )
                 else:
-                    # Assume seconds since 1970-01-01
+                    # Units not understood: fall back to seconds since 1970-01-01, and warn,
+                    # since that assumption is wrong for any other epoch.
+                    warnings.warn(
+                        f"TIME units {units!r} not understood; assuming "
+                        "'seconds since 1970-01-01'.",
+                        stacklevel=2,
+                    )
                     time_datetime = pd.to_datetime(
                         time_coord.values,
                         unit="s",
@@ -831,7 +876,9 @@ def standardize_time_coordinate(ds: xr.Dataset) -> xr.Dataset:
         "long_name": "Time",
         "standard_name": "time",
         "calendar": "gregorian",
-        "units": "datetime64[ns]",  # Use datetime64 units for clarity
+        # A valid UDUNITS/CF string, not the internal numpy dtype name. The actual
+        # on-disk encoding for the datetime64 values is chosen by xarray at write time.
+        "units": "seconds since 1970-01-01T00:00:00Z",
         "vocabulary": "http://vocab.nerc.ac.uk/collection/P01/current/ELTMEP01/",
     }
 
@@ -1811,7 +1858,12 @@ def standardise_data(ds: xr.Dataset, file_name: str) -> xr.Dataset:
     # 8) Standardize units
     ds = standardize_units(ds)
 
-    # 9) Apply cleaned metadata and reorder according to canonical order
+    # 9) Apply cleaned metadata and reorder according to canonical order.
+    # Drop internal working structures that leaked into attrs: these are nested dicts
+    # (not netCDF-serialisable) and are only used during processing, not in the output.
+    # (applied_variable_mapping is intentionally kept — it is part of the public attrs.)
+    for _internal_attr in ("files", "variable_mapping", "original_variable_metadata"):
+        cleaned.pop(_internal_attr, None)
     ds.attrs = cleaned
     ds.attrs = reorder_metadata(ds.attrs)
 

--- a/amocatlas/utilities.py
+++ b/amocatlas/utilities.py
@@ -8,12 +8,16 @@ This module provides shared utility functions including:
 - Decorator functions for default parameters
 """
 
+from datetime import datetime, timezone
 from ftplib import FTP
 from functools import wraps
 from importlib import resources
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
+import hashlib
+import json
+import os
 import re
 import yaml
 
@@ -26,6 +30,13 @@ from amocatlas import logger
 from amocatlas.logger import log_debug
 
 log = logger.log
+
+#: (connect, read) timeout in seconds for network downloads, so a stalled server
+#: cannot hang a download indefinitely.
+DOWNLOAD_TIMEOUT = (30, 300)
+
+#: Suffix for the JSON provenance sidecar written next to each downloaded file.
+PROVENANCE_SUFFIX = ".provenance.json"
 
 
 def get_project_root() -> Path:
@@ -495,26 +506,99 @@ def download_file(
         return str(local_filename)
 
     parsed_url = urlparse(url)
-
-    if parsed_url.scheme in ("http", "https"):
-        # HTTP(S) download
-        with requests.get(url, stream=True) as response:
-            response.raise_for_status()
-            with open(local_filename, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-
-    elif parsed_url.scheme == "ftp":
-        # FTP download
-        with FTP(parsed_url.netloc) as ftp:
-            ftp.login()  # anonymous login
-            with open(local_filename, "wb") as f:
-                ftp.retrbinary(f"RETR {parsed_url.path}", f.write)
-
-    else:
+    if parsed_url.scheme not in ("http", "https", "ftp"):
         raise ValueError(f"Unsupported URL scheme in {url}")
 
+    # Download to a temporary ".part" file and only rename into place once the transfer
+    # completes, so an interrupted download can never leave a truncated file that a later
+    # call would treat as a valid cached copy.
+    part_file = local_filename.with_name(local_filename.name + ".part")
+    response_headers: Dict[str, str] = {}
+
+    try:
+        if parsed_url.scheme in ("http", "https"):
+            # HTTP(S) download, with a timeout so a stalled server does not hang forever.
+            with requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:
+                response.raise_for_status()
+                response_headers = dict(response.headers)
+                with open(part_file, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+        else:
+            # FTP download
+            with FTP(parsed_url.netloc, timeout=DOWNLOAD_TIMEOUT[1]) as ftp:
+                ftp.login()  # anonymous login
+                with open(part_file, "wb") as f:
+                    ftp.retrbinary(f"RETR {parsed_url.path}", f.write)
+
+        # Atomic promotion of the completed download (same directory -> same filesystem).
+        os.replace(part_file, local_filename)
+    except BaseException:
+        part_file.unlink(missing_ok=True)
+        raise
+
+    _write_provenance_sidecar(local_filename, url, response_headers)
     return str(local_filename)
+
+
+def _write_provenance_sidecar(
+    local_filename: Path, url: str, headers: Dict[str, str]
+) -> None:
+    """Write a JSON provenance sidecar next to a downloaded file.
+
+    Records the source URL, download time (UTC), size, SHA-256, and the server's ETag /
+    Last-Modified when available, so a cached file's origin and version are recoverable.
+    A failure to write the sidecar never breaks the download.
+    """
+    try:
+        digest = hashlib.sha256()
+        with open(local_filename, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                digest.update(chunk)
+        provenance = {
+            "url": url,
+            "downloaded_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "bytes": local_filename.stat().st_size,
+            "sha256": digest.hexdigest(),
+        }
+        etag = headers.get("ETag") or headers.get("etag")
+        last_modified = headers.get("Last-Modified") or headers.get("last-modified")
+        if etag:
+            provenance["etag"] = etag
+        if last_modified:
+            provenance["last_modified"] = last_modified
+        sidecar = local_filename.with_name(local_filename.name + PROVENANCE_SUFFIX)
+        sidecar.write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
+    except OSError as e:
+        log_debug("Could not write provenance sidecar for %s: %s", local_filename, e)
+
+
+def read_provenance(file_path: Union[str, Path]) -> Optional[Dict]:
+    """Return the provenance sidecar for a downloaded file, or None if absent.
+
+    Parameters
+    ----------
+    file_path : str or Path
+        Path to the downloaded data file (not the sidecar itself).
+
+    Returns
+    -------
+    dict or None
+        The recorded provenance (url, downloaded_at, bytes, sha256, and optionally etag /
+        last_modified), or None if no sidecar exists or it cannot be read.
+
+    """
+    path = Path(file_path)
+    sidecar = path.with_name(path.name + PROVENANCE_SUFFIX)
+    if not sidecar.exists():
+        return None
+    try:
+        return json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        log_debug("Could not read provenance sidecar %s: %s", sidecar, e)
+        return None
 
 
 def parse_ascii_header(

--- a/tests/test_standardise.py
+++ b/tests/test_standardise.py
@@ -42,6 +42,11 @@ class TestStandardizeData:
         assert isinstance(mapping, dict)
         assert len(mapping) > 0
 
+        # Internal working structures must not leak into the output attrs
+        # (they are nested dicts and not netCDF-serialisable).
+        for internal in ("files", "variable_mapping", "original_variable_metadata"):
+            assert internal not in standardized.attrs
+
         # Should have standardized variable names
         std_vars = list(standardized.data_vars)
 
@@ -301,3 +306,48 @@ class TestConflictResolution:
             )
         assert result == "a considerably longer description"
         assert not [w for w in caught if "Metadata conflict" in str(w.message)]
+
+
+class TestTimeCoordinate:
+    """TIME coordinate standardisation, including non-1970 epochs."""
+
+    def test_parse_cf_time_units(self):
+        """CF units strings parse into (pandas unit, origin); junk returns None."""
+        assert standardise._parse_cf_time_units("days since 1950-01-01") == (
+            "D",
+            "1950-01-01",
+        )
+        assert standardise._parse_cf_time_units(
+            "seconds since 1970-01-01T00:00:00Z"
+        ) == ("s", "1970-01-01T00:00:00Z")
+        assert standardise._parse_cf_time_units("hours since 2000-01-01") == (
+            "h",
+            "2000-01-01",
+        )
+        assert standardise._parse_cf_time_units("garbage") is None
+        assert standardise._parse_cf_time_units("furlongs since 1900") is None
+
+    def test_numeric_time_honours_declared_epoch(self):
+        """A 'days since 1950-01-01' coordinate decodes to 1950, not 1970."""
+        ds = xr.Dataset(coords={"TIME": ("TIME", [0.0, 1.0, 365.0])})
+        ds["TIME"].attrs["units"] = "days since 1950-01-01"
+        out = standardise.standardize_time_coordinate(ds)
+        assert pd.Timestamp(out["TIME"].values[0]) == pd.Timestamp("1950-01-01")
+        assert pd.Timestamp(out["TIME"].values[1]) == pd.Timestamp("1950-01-02")
+        assert pd.Timestamp(out["TIME"].values[2]) == pd.Timestamp("1951-01-01")
+
+    def test_unknown_units_warn_and_fall_back(self):
+        """Unrecognised TIME units warn and fall back to seconds since 1970."""
+        ds = xr.Dataset(coords={"TIME": ("TIME", [0.0, 1.0])})
+        ds["TIME"].attrs["units"] = "weird units"
+        with pytest.warns(UserWarning, match="not understood"):
+            out = standardise.standardize_time_coordinate(ds)
+        assert pd.Timestamp(out["TIME"].values[0]) == pd.Timestamp("1970-01-01")
+
+    def test_output_units_is_udunits_not_dtype_name(self):
+        """Standardised TIME reports a UDUNITS string, not the numpy dtype name."""
+        ds = xr.Dataset(coords={"TIME": ("TIME", [0.0, 1.0])})
+        ds["TIME"].attrs["units"] = "seconds since 1970-01-01"
+        out = standardise.standardize_time_coordinate(ds)
+        assert out["TIME"].attrs["units"] == "seconds since 1970-01-01T00:00:00Z"
+        assert "datetime64" not in out["TIME"].attrs["units"]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -663,3 +663,116 @@ def test_set_data_dir_uses_logging() -> None:
 
         # Verify the directory was actually set
         assert utilities._user_data_dir == Path(temp_dir).expanduser().resolve()
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streaming ``requests`` response.
+
+    Yields the given byte chunks from ``iter_content``; if ``raise_on_chunk`` is set,
+    raises ``ConnectionError`` when that chunk index is reached, to simulate a transfer
+    that fails partway through.
+    """
+
+    def __init__(
+        self,
+        chunks: list,
+        headers: dict = None,
+        raise_on_chunk: int = None,
+    ) -> None:
+        self._chunks = chunks
+        self.headers = headers or {}
+        self._raise_on_chunk = raise_on_chunk
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def iter_content(self, chunk_size: int = 8192):
+        for i, chunk in enumerate(self._chunks):
+            if self._raise_on_chunk is not None and i == self._raise_on_chunk:
+                raise ConnectionError("simulated mid-transfer failure")
+            yield chunk
+
+
+class TestDownloadProvenance:
+    """Atomic downloads, provenance sidecars, and read_provenance()."""
+
+    def test_successful_download_writes_provenance_sidecar(self, monkeypatch) -> None:
+        """A completed download promotes the file and writes a matching sidecar."""
+        import hashlib
+
+        payload_chunks = [b"hello ", b"world"]
+        payload = b"".join(payload_chunks)
+        headers = {"ETag": '"abc123"', "Last-Modified": "Wed, 13 Aug 2026 00:00:00 GMT"}
+
+        def fake_get(url, stream=True, timeout=None):
+            return _FakeResponse(payload_chunks, headers=headers)
+
+        monkeypatch.setattr(utilities.requests, "get", fake_get)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = utilities.download_file(
+                "https://example.com/data.nc", tmp, filename="data.nc"
+            )
+            data_file = Path(path)
+
+            # File promoted into place, no leftover .part
+            assert data_file.read_bytes() == payload
+            assert not data_file.with_name(data_file.name + ".part").exists()
+
+            # Sidecar round-trips via read_provenance with correct content
+            prov = utilities.read_provenance(data_file)
+            assert prov is not None
+            assert prov["url"] == "https://example.com/data.nc"
+            assert prov["bytes"] == len(payload)
+            assert prov["sha256"] == hashlib.sha256(payload).hexdigest()
+            assert prov["etag"] == '"abc123"'
+            assert prov["last_modified"] == "Wed, 13 Aug 2026 00:00:00 GMT"
+
+    def test_failed_download_leaves_no_partial_file(self, monkeypatch) -> None:
+        """A transfer that fails mid-stream leaves neither the .part nor final file."""
+
+        def fake_get(url, stream=True, timeout=None):
+            return _FakeResponse([b"partial", b"more"], raise_on_chunk=1)
+
+        monkeypatch.setattr(utilities.requests, "get", fake_get)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with pytest.raises(ConnectionError):
+                utilities.download_file(
+                    "https://example.com/data.nc", tmp, filename="data.nc"
+                )
+            final = Path(tmp) / "data.nc"
+            assert not final.exists()
+            assert not final.with_name(final.name + ".part").exists()
+            # No sidecar for a download that never completed
+            assert utilities.read_provenance(final) is None
+
+    def test_read_provenance_missing_sidecar_returns_none(self) -> None:
+        """read_provenance returns None when no sidecar exists beside the file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_file = Path(tmp) / "nosidecar.nc"
+            data_file.write_bytes(b"data")
+            assert utilities.read_provenance(data_file) is None
+
+    def test_provenance_omits_absent_http_headers(self, monkeypatch) -> None:
+        """When the server sends no ETag/Last-Modified, those keys are omitted."""
+
+        def fake_get(url, stream=True, timeout=None):
+            return _FakeResponse([b"x"], headers={})
+
+        monkeypatch.setattr(utilities.requests, "get", fake_get)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = utilities.download_file(
+                "https://example.com/x.nc", tmp, filename="x.nc"
+            )
+            prov = utilities.read_provenance(path)
+            assert prov is not None
+            assert "etag" not in prov
+            assert "last_modified" not in prov


### PR DESCRIPTION
## Summary

Two latent metadata bugs in `standardise.py` (review §1e, §1d) plus a download-robustness/provenance change in `utilities.py`, shipped together. None corrupts current shipped data (see below), but each is a trap for the next reader or a gap in provenance, which is the core thing this package exists to get right.

## TIME coordinate: honour the declared epoch and units

`standardize_time_coordinate` had two identical branches that both hardcoded `unit="s", origin="1970-01-01"`, so a numeric TIME coordinate declared as e.g. `days since 1950-01-01` would decode to January 1970. It also set the output `units` attribute to `"datetime64[ns]"`, which is the numpy dtype name, not a valid UDUNITS/CF string, and contradicts the function's own docstring and the adjacent comment.

Now:
- A new `_parse_cf_time_units()` parses `"<interval> since <date>"` strings (seconds/minutes/hours/days) into a pandas unit and origin, so the declared interval and epoch are honoured (`days since 1950-01-01` → 1950).
- Unrecognised units fall back to seconds-since-1970 **and emit a warning**, instead of silently assuming that epoch.
- The output `units` attribute is a valid UDUNITS string (`seconds since 1970-01-01T00:00:00Z`); the on-disk encoding for the datetime64 values is left to xarray at write time.

Why it wasn't corrupting data today: xarray decodes CF times on open, so most readers deliver datetime64 (dtype `M`) and skip this numeric branch; the one reader that opts out converts by hand beforehand. This removes the trap for the next reader.

## Strip internal working structures from output attrs

The final `ds.attrs` carried three nested-dict working structures — `files`, `variable_mapping`, `original_variable_metadata` — which are used only during processing, are not read from the output anywhere, and are not netCDF-serialisable (raw `to_netcdf` raised `TypeError`). They are now removed before the dataset is returned. `applied_variable_mapping` is intentionally kept (it is part of the public attribute order, the schema, and is consumed by the report).

## Download robustness and provenance sidecars

`download_file()` in `utilities.py` is hardened and now records provenance for every downloaded file:

- **Atomic writes.** The download streams to a `<name>.part` temporary file in the same directory and is promoted with `os.replace()` only after the transfer completes. An interrupted download can no longer leave a truncated file that a later run would treat as a valid cached copy. On any failure the `.part` file is removed.
- **Timeouts.** HTTP(S) and FTP downloads use a `(connect, read)` timeout of `(30, 300)` seconds (`DOWNLOAD_TIMEOUT`), so a stalled server cannot hang a download indefinitely.
- **Provenance sidecars.** After a successful download, a JSON sidecar `<name>.provenance.json` is written next to the file recording the source URL, download time (UTC), byte size, SHA-256, and the server's ETag / Last-Modified when present. A failure to write the sidecar is logged and never breaks the download.
- **Accessor.** New public `read_provenance(file_path)` returns the sidecar dict for a downloaded file, or `None` if absent/unreadable.

## Breaking changes and migration

- **New files in the data cache.** Every download now writes a `<name>.provenance.json` sidecar alongside the data file (typically under `~/.amocatlas_data/`). Tooling that lists or globs the cache directory and assumes only data files are present should filter out `*.provenance.json`. No existing file is modified or moved.
- **Downloads can now time out.** A transfer that stalls beyond the read timeout (300 s with no data) now raises instead of hanging. A legitimately slow server that previously blocked forever could now fail; rerun to resume (the atomic `.part` handling means no partial file is left behind).
- **New public API.** `utilities.read_provenance()` and the module constants `DOWNLOAD_TIMEOUT` / `PROVENANCE_SUFFIX` are added. No existing signature changed: `download_file()` keeps its arguments and still returns the path to the data file.

## Tests

New in `test_standardise.py`: `_parse_cf_time_units` cases; a `days since 1950-01-01` coordinate decodes to 1950; unrecognised units warn and fall back to 1970; output units is UDUNITS not the dtype name. The end-to-end RAPID test also asserts the three internal dict attrs are absent from the output.

New in `test_utilities.py` (`TestDownloadProvenance`): a successful download promotes the file and writes a sidecar that round-trips through `read_provenance()` with the correct SHA-256, byte size, ETag, and Last-Modified; a download that fails mid-stream leaves neither the `.part` nor the final file; a file with no sidecar returns `None`; and a response without ETag/Last-Modified omits those keys.
